### PR TITLE
Feature: router

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,9 @@
+import { RouterProvider } from "react-router-dom";
+import router from "./router/router";
+import GlobalFallback from "./components/layout/fallback/GlobalFallback";
+
 function App() {
-  return <p className="text-pink-600">hello world</p>;
+  return <RouterProvider router={router} fallbackElement={<GlobalFallback />} />;
 }
 
 export default App;

--- a/src/components/common/Navbar.tsx
+++ b/src/components/common/Navbar.tsx
@@ -6,7 +6,7 @@ import Who from "../../assets/svg/who.svg?react";
 
 const GNB = [
   { icon: <Home />, label: "홈", path: "/" },
-  { icon: <Sns />, label: "일기 공유", path: "/sns" },
+  { icon: <Sns />, label: "일기 공유", path: "/explore" },
   { icon: <Album />, label: "앨범", path: "/album" },
   { icon: <Who />, label: "마이페이지", path: "/mypage" },
 ];

--- a/src/components/common/Navbar.tsx
+++ b/src/components/common/Navbar.tsx
@@ -3,12 +3,13 @@ import Home from "../../assets/svg/home.svg?react";
 import Sns from "../../assets/svg/sns.svg?react";
 import Album from "../../assets/svg/album.svg?react";
 import Who from "../../assets/svg/who.svg?react";
+import RoutePaths from "../../constants/routePath";
 
 const GNB = [
-  { icon: <Home />, label: "홈", path: "/" },
-  { icon: <Sns />, label: "일기 공유", path: "/explore" },
-  { icon: <Album />, label: "앨범", path: "/album" },
-  { icon: <Who />, label: "마이페이지", path: "/mypage" },
+  { icon: <Home />, label: "홈", path: RoutePaths.home },
+  { icon: <Sns />, label: "일기 공유", path: RoutePaths.explore },
+  { icon: <Album />, label: "앨범", path: RoutePaths.album },
+  { icon: <Who />, label: "마이페이지", path: RoutePaths.mypage },
 ];
 
 const Navbar = () => {

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,0 +1,15 @@
+import { Outlet } from "react-router-dom";
+import Navbar from "../common/Navbar";
+
+const Layout = () => {
+  return (
+    <div className="flex h-screen w-screen flex-col">
+      <div className="flex-grow">
+        <Outlet />
+      </div>
+      <Navbar />
+    </div>
+  );
+};
+
+export default Layout;

--- a/src/components/layout/fallback/GlobalFallback.tsx
+++ b/src/components/layout/fallback/GlobalFallback.tsx
@@ -1,0 +1,5 @@
+const GlobalFallback = () => {
+  return <div>앱 로딩중...</div>;
+};
+
+export default GlobalFallback;

--- a/src/components/layout/fallback/PageFallback.tsx
+++ b/src/components/layout/fallback/PageFallback.tsx
@@ -1,0 +1,5 @@
+const PageFallback = () => {
+  return <div>페이지 로딩중...</div>;
+};
+
+export default PageFallback;

--- a/src/constants/routePath.ts
+++ b/src/constants/routePath.ts
@@ -1,0 +1,8 @@
+const RoutePaths = {
+  home: "/",
+  explore: "/explore",
+  album: "/album",
+  mypage: "/mypage",
+};
+
+export default RoutePaths;

--- a/src/pages/Album.tsx
+++ b/src/pages/Album.tsx
@@ -1,0 +1,5 @@
+const Album = () => {
+  return <div></div>;
+};
+
+export default Album;

--- a/src/pages/Explore.tsx
+++ b/src/pages/Explore.tsx
@@ -1,0 +1,5 @@
+const Explore = () => {
+  return <div></div>;
+};
+
+export default Explore;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,5 @@
+const Home = () => {
+  return <div></div>;
+};
+
+export default Home;

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -1,0 +1,5 @@
+const Mypage = () => {
+  return <div></div>;
+};
+
+export default Mypage;

--- a/src/pages/error/Error.tsx
+++ b/src/pages/error/Error.tsx
@@ -1,0 +1,5 @@
+const Error = () => {
+  return <div>Error</div>;
+};
+
+export default Error;

--- a/src/pages/error/NotFoundError.tsx
+++ b/src/pages/error/NotFoundError.tsx
@@ -1,0 +1,5 @@
+const NotFoundError = () => {
+  return <div>404</div>;
+};
+
+export default NotFoundError;

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -1,0 +1,81 @@
+import { lazy, Suspense } from "react";
+import { createBrowserRouter, RouteObject } from "react-router-dom";
+import GlobalFallback from "../components/layout/fallback/GlobalFallback";
+import PageFallback from "../components/layout/fallback/PageFallback";
+import Layout from "../components/layout/Layout";
+
+const HomePage = lazy(() => import("../pages/Home"));
+const ExplorePage = lazy(() => import("../pages/Explore"));
+const AlbumPage = lazy(() => import("../pages/Album"));
+const Mypage = lazy(() => import("../pages/Mypage"));
+const ErrorPage = lazy(() => import("../pages/error/Error"));
+const NotFoundErrorPage = lazy(() => import("../pages/error/NotFoundError"));
+
+const RoutePaths = {
+  home: "/",
+  explore: "/explore",
+  album: "/album",
+  mypage: "/mypage",
+};
+
+const routes: RouteObject[] = [
+  {
+    path: RoutePaths.home,
+    element: (
+      <Suspense fallback={<GlobalFallback />}>
+        <Layout />
+      </Suspense>
+    ),
+    errorElement: (
+      <Suspense fallback={<GlobalFallback />}>
+        <ErrorPage />
+      </Suspense>
+    ),
+    children: [
+      {
+        index: true,
+        element: (
+          <Suspense fallback={<PageFallback />}>
+            <HomePage />
+          </Suspense>
+        ),
+      },
+      {
+        path: RoutePaths.explore,
+        element: (
+          <Suspense fallback={<PageFallback />}>
+            <ExplorePage />
+          </Suspense>
+        ),
+      },
+      {
+        path: RoutePaths.album,
+        element: (
+          <Suspense fallback={<PageFallback />}>
+            <AlbumPage />
+          </Suspense>
+        ),
+      },
+      {
+        path: RoutePaths.mypage,
+        element: (
+          <Suspense fallback={<PageFallback />}>
+            <Mypage />
+          </Suspense>
+        ),
+      },
+    ],
+  },
+  {
+    path: "*",
+    element: (
+      <Suspense fallback={<GlobalFallback />}>
+        <NotFoundErrorPage />
+      </Suspense>
+    ),
+  },
+];
+
+const router = createBrowserRouter(routes);
+
+export default router;

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -3,6 +3,7 @@ import { createBrowserRouter, RouteObject } from "react-router-dom";
 import GlobalFallback from "../components/layout/fallback/GlobalFallback";
 import PageFallback from "../components/layout/fallback/PageFallback";
 import Layout from "../components/layout/Layout";
+import RoutePaths from "../constants/routePath";
 
 const HomePage = lazy(() => import("../pages/Home"));
 const ExplorePage = lazy(() => import("../pages/Explore"));
@@ -10,13 +11,6 @@ const AlbumPage = lazy(() => import("../pages/Album"));
 const Mypage = lazy(() => import("../pages/Mypage"));
 const ErrorPage = lazy(() => import("../pages/error/Error"));
 const NotFoundErrorPage = lazy(() => import("../pages/error/NotFoundError"));
-
-const RoutePaths = {
-  home: "/",
-  explore: "/explore",
-  album: "/album",
-  mypage: "/mypage",
-};
 
 const routes: RouteObject[] = [
   {


### PR DESCRIPTION
## 이슈
- #34 

## 구현 내용
- [x] router
- [x] lazy, suspense
- [x] 뷰 페이지 라우팅
- [x] 로딩 페이지 라우팅
- [x] 에러 페이지 라우팅

## 상세 내용
- Lazy 와 Suspense 를 활용한 최적화
- `Global fallback`과 `Page fallback` 구분
- `Layout` 컴포넌트로 Navbar 컴포넌트 중복 방지

## 고민한 내용
### React Lazy
- `Suspense` 하위에 `Lazy` 사용
- `Lazy` 를 사용하면 초기 화면이 아닌 해당 `path`로 이동 시 로드
- `Suspense` 는 렌더링이 완료되지 않은 컴포넌트를 바로 보여주지 않고 fallback 화면을 보여줌
- 초기 로딩 속도는 빨라지지만 페이지 이동 간 로딩이 생김
  - 일단 적용해 둔 뒤 변경
  - 현재 상태는 로딩이 빨라 약간의 깜빡임처럼 느껴짐
  - 개발이 진행될 수록 이미지를 표시할 것이 많아서 로딩이 길어질 것으로 예상됨 => 앱이기 때문에 초반 로딩이 조금 더 긴 것이 더 좋을 수도 있을 듯
