### PR TITLE
Feature: album page

### DIFF
--- a/src/components/common/Tag.tsx
+++ b/src/components/common/Tag.tsx
@@ -14,7 +14,7 @@ interface TagProps {
 const Tag = ({ text, selected, onClick }: TagProps) => {
   return (
     <button
-      className={`h-fit w-fit rounded-full px-400 py-200 font-Binggrae text-detail-1 font-regular ${selected ? "bg-primary-medium text-white" : "bg-primary-light-2 text-primary-normal"}`}
+      className={`h-fit w-fit whitespace-nowrap rounded-full px-400 py-200 font-Binggrae text-detail-1 font-regular ${selected ? "bg-primary-medium text-white" : "bg-primary-light-2 text-primary-normal"}`}
       onClick={onClick}
     >{`# ${text}`}</button>
   );

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -56,9 +56,7 @@ const Layout = () => {
           menuHandler={() => {}}
         />
       )}
-      <div className="flex-grow overflow-scroll">
-        <Outlet />
-      </div>
+      <Outlet></Outlet>
       {!shouldDeleteNavBar() && <Navbar NavList={GNB} />}
     </div>
   );

--- a/src/components/pages/album/Thumbnail.stories.tsx
+++ b/src/components/pages/album/Thumbnail.stories.tsx
@@ -1,15 +1,28 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { MemoryRouter } from "react-router-dom";
+import dummy from "../../../assets/dummy/_Image.png";
 
 import Thumbnail from "./Thumbnail";
 
 const meta: Meta<typeof Thumbnail> = {
   component: Thumbnail,
   tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
 };
 
 export default meta;
 type Story = StoryObj<typeof Thumbnail>;
 
 export const Primary: Story = {
-  args: {},
+  args: {
+    src: dummy,
+    alt: "1",
+    diaryId: 1,
+  },
 };

--- a/src/components/pages/album/Thumbnail.tsx
+++ b/src/components/pages/album/Thumbnail.tsx
@@ -10,7 +10,7 @@ interface ThubnailProps {
  * @returns
  */
 const Thumbnail = ({ src, alt }: ThubnailProps) => {
-  return <img src={src} alt={alt} className="h-[11.125rem] w-[6.375rem] bg-gray-200"></img>;
+  return <img src={src} alt={alt} className="h-[11.125rem] w-[6.375rem]"></img>;
 };
 
 export default Thumbnail;

--- a/src/components/pages/album/Thumbnail.tsx
+++ b/src/components/pages/album/Thumbnail.tsx
@@ -1,16 +1,29 @@
+import { useNavigate } from "react-router-dom";
+import RoutePaths from "../../../constants/routePath";
+
 interface ThubnailProps {
   src: string;
   alt: string;
+  diaryId: number;
 }
 
 /**
  * 앨범 썸내일
  * @param src 이미지 img
  * @param alt 이미지 alt
+ * @param diaryId 일기 ID
  * @returns
  */
-const Thumbnail = ({ src, alt }: ThubnailProps) => {
-  return <img src={src} alt={alt} className="h-[11.125rem] w-[6.375rem]"></img>;
+const Thumbnail = ({ src, alt, diaryId }: ThubnailProps) => {
+  const navigate = useNavigate();
+
+  const onClickHandler = () => {
+    navigate(`${RoutePaths.diary}/${diaryId}`);
+  };
+
+  return (
+    <img src={src} alt={alt} className="h-[11.125rem] w-[6.375rem]" onClick={onClickHandler}></img>
+  );
 };
 
 export default Thumbnail;

--- a/src/components/pages/album/ThumbnailGrid.stories.tsx
+++ b/src/components/pages/album/ThumbnailGrid.stories.tsx
@@ -1,15 +1,31 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { MemoryRouter } from "react-router-dom";
+import dummy from "../../../assets/dummy/_Image.png";
 
 import ThumbnailGrid from "./ThumbnailGrid";
 
 const meta: Meta<typeof ThumbnailGrid> = {
   component: ThumbnailGrid,
   tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
 };
 
 export default meta;
 type Story = StoryObj<typeof ThumbnailGrid>;
 
 export const Primary: Story = {
-  args: {},
+  args: {
+    diaries: [
+      {
+        diaryId: 1,
+        mainImgUrl: dummy,
+      },
+    ],
+  },
 };

--- a/src/components/pages/album/ThumbnailGrid.tsx
+++ b/src/components/pages/album/ThumbnailGrid.tsx
@@ -16,7 +16,12 @@ const ThumbnailGrid = ({ diaries }: ThumbnailGridProps) => {
   return (
     <div className="grid grid-cols-3 place-items-center gap-300 overflow-scroll py-800">
       {diaries.map((diary) => (
-        <Thumbnail src={diary.mainImgUrl} alt={diary.mainImgUrl} key={diary.diaryId} />
+        <Thumbnail
+          src={diary.mainImgUrl}
+          alt={diary.mainImgUrl}
+          diaryId={diary.diaryId}
+          key={diary.diaryId}
+        />
       ))}
     </div>
   );

--- a/src/components/pages/album/ThumbnailGrid.tsx
+++ b/src/components/pages/album/ThumbnailGrid.tsx
@@ -1,24 +1,22 @@
 import Thumbnail from "./Thumbnail";
 
-//일기 더미 데이터
-const diarys = [
-  { diaryId: 1, imgURL: "1", day: "9월 21일" },
-  { diaryId: 2, imgURL: "2", day: "9월 22일" },
-  { diaryId: 3, imgURL: "3", day: "9월 23일" },
-  { diaryId: 4, imgURL: "4", day: "9월 24일" },
-  { diaryId: 5, imgURL: "5", day: "9월 25일" },
-  { diaryId: 6, imgURL: "6", day: "9월 26일" },
-];
+interface ThumbnailGridProps {
+  diaries: {
+    diaryId: number;
+    mainImgUrl: string;
+  }[];
+}
 
 /**
  * 앨범 화면에서 보이는 썸내일 그리드
+ * @param diaries diaryId, mainImgUrl 배열
  * @returns
  */
-const ThumbnailGrid = () => {
+const ThumbnailGrid = ({ diaries }: ThumbnailGridProps) => {
   return (
-    <div className="grid grid-cols-3 place-items-center gap-300">
-      {diarys.map((diary) => (
-        <Thumbnail src={diary.imgURL} alt={diary.day} key={diary.diaryId} />
+    <div className="grid grid-cols-3 place-items-center gap-300 overflow-scroll">
+      {diaries.map((diary) => (
+        <Thumbnail src={diary.mainImgUrl} alt={diary.mainImgUrl} key={diary.diaryId} />
       ))}
     </div>
   );

--- a/src/components/pages/album/ThumbnailGrid.tsx
+++ b/src/components/pages/album/ThumbnailGrid.tsx
@@ -14,7 +14,7 @@ interface ThumbnailGridProps {
  */
 const ThumbnailGrid = ({ diaries }: ThumbnailGridProps) => {
   return (
-    <div className="grid grid-cols-3 place-items-center gap-300 overflow-scroll">
+    <div className="grid grid-cols-3 place-items-center gap-300 overflow-scroll py-800">
       {diaries.map((diary) => (
         <Thumbnail src={diary.mainImgUrl} alt={diary.mainImgUrl} key={diary.diaryId} />
       ))}

--- a/src/pages/Album.tsx
+++ b/src/pages/Album.tsx
@@ -115,7 +115,7 @@ const Album = () => {
         >
           <span className="font-Binggrae text-body-1 font-regular">앨범</span>
         </div>
-        <div className="flex flex-col gap-800 px-700">
+        <div className="flex flex-col px-700">
           <div className="sticky top-0 flex flex-col gap-500 bg-white py-400">
             <SearchBar onEnter={() => {}} />
             <div

--- a/src/pages/Album.tsx
+++ b/src/pages/Album.tsx
@@ -1,28 +1,140 @@
 import Tag from "../components/common/Tag";
 import SearchBar from "../components/pages/album/SearchBar";
 import ThumbnailGrid from "../components/pages/album/ThumbnailGrid";
+import Dummy from "../assets/dummy/_Image.png";
+import { useEffect, useRef, useState } from "react";
+
+const AlbumData = {
+  diaries: [
+    {
+      diaryId: 1,
+      mainImgUrl: Dummy,
+    },
+    {
+      diaryId: 2,
+      mainImgUrl: Dummy,
+    },
+    {
+      diaryId: 3,
+      mainImgUrl: Dummy,
+    },
+    {
+      diaryId: 4,
+      mainImgUrl: Dummy,
+    },
+    {
+      diaryId: 5,
+      mainImgUrl: Dummy,
+    },
+    {
+      diaryId: 6,
+      mainImgUrl: Dummy,
+    },
+    {
+      diaryId: 7,
+      mainImgUrl: Dummy,
+    },
+    {
+      diaryId: 8,
+      mainImgUrl: Dummy,
+    },
+    {
+      diaryId: 9,
+      mainImgUrl: Dummy,
+    },
+    {
+      diaryId: 10,
+      mainImgUrl: Dummy,
+    },
+    {
+      diaryId: 11,
+      mainImgUrl: Dummy,
+    },
+    {
+      diaryId: 21,
+      mainImgUrl: Dummy,
+    },
+    {
+      diaryId: 12,
+      mainImgUrl: Dummy,
+    },
+    {
+      diaryId: 23,
+      mainImgUrl: Dummy,
+    },
+    {
+      diaryId: 14,
+      mainImgUrl: Dummy,
+    },
+    {
+      diaryId: 25,
+      mainImgUrl: Dummy,
+    },
+  ],
+};
 
 /**
  * 앨범 화면
  * @returns
  */
 const Album = () => {
+  const [isTagsVisible, setTagsVisible] = useState(true);
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null); // 스크롤 컨테이너 ref
+  const lastScrollY = useRef(0); // 이전 스크롤 위치 저장
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (scrollContainerRef.current) {
+        const currentScrollY = scrollContainerRef.current.scrollTop;
+
+        if (currentScrollY > lastScrollY.current) {
+          setTagsVisible(false); // 아래로 스크롤 시 태그 숨기기
+        } else {
+          setTagsVisible(true); // 위로 스크롤 시 태그 보이기
+        }
+
+        lastScrollY.current = currentScrollY; // 이전 스크롤 위치 업데이트
+        console.log(`현재 스크롤 위치: ${currentScrollY}px`);
+      }
+    };
+
+    const scrollContainer = scrollContainerRef.current;
+
+    scrollContainer?.addEventListener("scroll", handleScroll);
+
+    return () => {
+      scrollContainer?.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
   return (
-    <div className="flex flex-col gap-400">
-      <div
-        className={`flex w-full items-center justify-center bg-transparent px-800 py-300 text-black dark:text-white`}
-      >
-        <span className="font-Binggrae text-body-1 font-regular">앨범</span>
-      </div>
-      <div className="flex flex-col gap-800 px-700">
-        <div className="flex flex-col gap-500">
-          <SearchBar onEnter={() => {}}></SearchBar>
-          <div className="flex gap-400">
-            <Tag text="행복" selected={false} />
-            <Tag text="행복" selected={false} />
-          </div>
+    <div className="flex-grow overflow-scroll" ref={scrollContainerRef}>
+      <div className="flex flex-col">
+        <div
+          className={`flex w-full items-center justify-center bg-transparent px-800 py-300 text-black dark:text-white`}
+        >
+          <span className="font-Binggrae text-body-1 font-regular">앨범</span>
         </div>
-        <ThumbnailGrid />
+        <div className="flex flex-col gap-800 px-700">
+          <div className="sticky top-0 flex flex-col gap-500 bg-white py-400">
+            <SearchBar onEnter={() => {}} />
+            <div
+              className={`absolute flex w-full gap-400 overflow-scroll bg-white py-500 transition-all duration-300 ${isTagsVisible ? "top-14 opacity-100" : "top-10 opacity-0"}`}
+            >
+              <Tag text="기쁨" selected={false} />
+              <Tag text="슬픔" selected={false} />
+              <Tag text="분노" selected={false} />
+              <Tag text="공포" selected={false} />
+              <Tag text="혐오" selected={false} />
+              <Tag text="수치" selected={false} />
+              <Tag text="놀람" selected={false} />
+              <Tag text="궁금" selected={false} />
+              <Tag text="무난" selected={false} />
+            </div>
+          </div>
+          <div className="h-4"></div>
+          <ThumbnailGrid diaries={AlbumData.diaries} />
+        </div>
       </div>
     </div>
   );

--- a/src/pages/diary/Diary.tsx
+++ b/src/pages/diary/Diary.tsx
@@ -79,7 +79,13 @@ const NoDiary = () => {
         </div>
       </div>
       <div className="mb-[1.875rem]">
-        <Button size="big" active={true} text="일기 작성하기" onClickHandler={() => {}} />
+        <Button
+          size="big"
+          active={true}
+          text="일기 작성하기"
+          onClickHandler={() => {}}
+          bgColor="light"
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## 이슈
- #37 

## 구현 내용
- [x] 앨범 화면 스크롤
- [x] 앨범 화면 컴포넌트 props 추가
- [x] 썸내일 로직 추가
- [x] layout에서 스크롤 제거

## 상세 내용
### 앨범 화면
![image](https://github.com/user-attachments/assets/a7371fd0-7b3d-4dd3-95d2-2840ef88b994)

### 앨범 화면 로직
https://github.com/user-attachments/assets/b13060ec-9d75-4bb2-915b-28367fc22097

## 고민한 내용
### 태그 목록을 보이는 방식
- 초기에는 `AppBar + 검색창 + 태그 목록`이 스크롤과 함께 올라갔음
- 검색창과 태그 목록은 올라가면 안된다고 생각함
- 태그와 검색창에 `sticky` 속성을 부여
  - 태그 목록이 너무 커 보여서 ui적으로 마음에 들지 않음
- 태그 목록을 스크롤을 내릴 때는 가리고 올릴 때는 보이게 하자!
  - 태그 목록의 상태 필요
  - 이를 위해 스크롤 상태를 관리해야 함
- `requestAnimationFrame`을 사용해서 프레임 당 스크롤 상태를 추적할지 그냥 `addEventListener`를 사용할지 고민
  - `requestAnimationFrame`은 스크롤 하지 않는 상태에서도 계속해서 갱신됨
  - 이를 제거하기위해 상태를 하나 더 둘 필요는 없다고 생각함
  - 간단하게 `addEventListener`로 구현
#### 스크롤 상태 추적
- `window.scroll` 을 이용하여 스크롤 상태를 가져오려고 시도함
- `Layout` 컴포넌트에서 `flex-grow overflow-scroll` 스타일을 부여했기 때문에 `Layout` 내부의 `div`에서 스크롤이 제어되고 있었기 때문에 실패함
- `Layout`의 `overflow-scroll` 엘리먼트의 `ref`를 통해 스크롤 관리가 필요
- `Layout` 하위의 `Outlet`으로는 `ref` 전달이 복잡함
  - 구조를 깔끔하게 하려다 코드의 복잡성만 올라갈 것이라고 판단함
- `overflow-scroll` 속성을 `Album` 컴포넌트로 이동시킴
```tsx
useEffect(() => {
    /**
     * scrollContainerRef의 스크롤 상태 추적
     */
    const handleScroll = () => {
      if (scrollContainerRef.current) {
        const currentScrollY = scrollContainerRef.current.scrollTop;

        if (currentScrollY > lastScrollY.current) {
          setTagsVisible(false); // 아래로 스크롤 시 태그 숨기기
        } else {
          setTagsVisible(true); // 위로 스크롤 시 태그 보이기
        }

        sessionStorage.setItem("scrollPosition", currentScrollY.toString());
        lastScrollY.current = currentScrollY; // 이전 스크롤 위치 업데이트
      }
    };

    scrollContainerRef.current?.addEventListener("scroll", handleScroll);
    return () => {
      scrollContainerRef.current?.removeEventListener("scroll", handleScroll);
    };
  }, []);

return (
    <div className="flex-grow overflow-scroll" ref={scrollContainerRef}>
    ...
  )
```

### 페이지 이동 시 스크롤 상태 저장
- 썸내일을 클릭해 일기 화면에 들어갔다 나오면 앨범화면이 젤 위로 올라감
  - UX적으로 좋지 못하다고 생각함
- 스크롤 상태를 어떻게 저장할지 고민
  - local storage: 영구적 저장소로 앨범 화면에서만 필요한 정보가 들어갈 이유가 없음
  - session storage: 앨범 화면을 볼 때만 유지
  - 전역상태: 전역으로 관리할 정보가 아님
- 세션 스토리지 사용하기로 결정함
- `useEffect`에서 세션 스토리지에서 불러옴
```tsx
useEffect(() => {
    const savedScrollPosition = sessionStorage.getItem("scrollPosition");

    if (savedScrollPosition && scrollContainerRef.current) {
      scrollContainerRef.current.scrollTop = parseInt(savedScrollPosition, 10);
      lastScrollY.current = parseInt(savedScrollPosition, 10);
    }
  }, []);

```