### PR TITLE
Feature/diary settings

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.js",
+    "css": "src/index.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
+}

--- a/package.json
+++ b/package.json
@@ -14,12 +14,17 @@
   "dependencies": {
     "autoprefixer": "^10.4.20",
     "axios": "^1.7.7",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.456.0",
     "postcss": "^8.4.47",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-error-boundary": "^4.1.2",
     "react-router-dom": "^6.26.2",
-    "tailwindcss": "^3.4.12"
+    "tailwind-merge": "^2.5.4",
+    "tailwindcss": "^3.4.12",
+    "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "1.9.0",
@@ -32,6 +37,7 @@
     "@storybook/react": "8.3.2",
     "@storybook/react-vite": "8.3.2",
     "@storybook/test": "8.3.2",
+    "@types/node": "^22.9.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/parser": "^8.6.0",

--- a/src/api/api.tsx
+++ b/src/api/api.tsx
@@ -223,7 +223,7 @@ interface DiaryExploreProps {
 
 /**
  * 탐색 화면 일기 목록 가져오기
- * @param param0
+ * @param param0 DiaryExploreProps
  * @returns
  */
 export const getExploreDiaries = async ({
@@ -240,7 +240,7 @@ export const getExploreDiaries = async ({
   }
 };
 
-interface newImageProps {
+interface NewImageProps {
   diaryId: string;
   content: string;
   style: string;
@@ -248,11 +248,30 @@ interface newImageProps {
 
 /**
  * 기존의 일기에 새로운 이미지 추가
- * @param param0 newImageProps
+ * @param param0 NewImageProps
  */
-export const addImageToDiary = async ({ diaryId, content, style }: newImageProps) => {
+export const postImageToDiary = async ({ diaryId, content, style }: NewImageProps) => {
   try {
     await axiosInstance.post(`/api/v1/diaries/${diaryId}/images`, { content, style });
+  } catch (error) {
+    throw error;
+  }
+};
+
+interface ModifiedDiaryProps {
+  diaryId: string;
+  content: string;
+  isPublic: boolean;
+}
+
+/**
+ * 일기 수정
+ * @param param0 ModifyDiaryProps
+ * @returns
+ */
+export const putModifiedDiary = async ({ diaryId, content, isPublic }: ModifiedDiaryProps) => {
+  try {
+    await axiosInstance.put(`/api/v1/diaries/${diaryId}`, { content, isPublic });
   } catch (error) {
     throw error;
   }

--- a/src/api/api.tsx
+++ b/src/api/api.tsx
@@ -276,3 +276,15 @@ export const putModifiedDiary = async ({ diaryId, content, isPublic }: ModifiedD
     throw error;
   }
 };
+
+/**
+ * 일기 삭제
+ * @param diaryId
+ */
+export const deleteDiary = async (diaryId: string) => {
+  try {
+    await axiosInstance.delete(`/api/v1/diaries/${diaryId}`);
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/components/common/BottomSheet/BottomSheet.stories.tsx
+++ b/src/components/common/BottomSheet/BottomSheet.stories.tsx
@@ -11,5 +11,7 @@ export default meta;
 type Story = StoryObj<typeof BottomSheet>;
 
 export const Primary: Story = {
-  args: {},
+  args: {
+    onClose: () => {},
+  },
 };

--- a/src/components/common/BottomSheet/BottomSheet.tsx
+++ b/src/components/common/BottomSheet/BottomSheet.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from "react";
 
 interface BottomSheetProps {
   children: ReactNode;
+  onClose: () => void;
 }
 
 /**
@@ -9,10 +10,16 @@ interface BottomSheetProps {
  * @param children 바텀 시트 구성 요소들
  * @returns
  */
-const BottomSheet = ({ children }: BottomSheetProps) => {
+const BottomSheet = ({ children, onClose }: BottomSheetProps) => {
   return (
-    <div className="flex h-screen w-screen flex-col items-center justify-end bg-black opacity-70">
-      <div className="mb-[2.5rem] flex h-fit w-[22rem] flex-col items-center gap-600 rounded-300 bg-white px-500 pb-600 pt-300 shadow-default">
+    <div
+      className="absolute left-0 top-0 z-50 flex h-screen w-screen flex-col items-center justify-end bg-black bg-opacity-70"
+      onClick={onClose}
+    >
+      <div
+        className="mb-[2.5rem] flex h-fit w-[22rem] flex-col items-center gap-600 rounded-300 bg-white px-500 pb-600 pt-300 shadow-default"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="h-[0.375rem] w-8 rounded-full bg-gray-200"></div>
         {children}
       </div>

--- a/src/components/common/BottomSheet/DeleteSettings.stories.tsx
+++ b/src/components/common/BottomSheet/DeleteSettings.stories.tsx
@@ -11,5 +11,7 @@ export default meta;
 type Story = StoryObj<typeof DeleteSettings>;
 
 export const Primary: Story = {
-  args: {},
+  args: {
+    onClose: () => {},
+  },
 };

--- a/src/components/common/BottomSheet/DeleteSettings.tsx
+++ b/src/components/common/BottomSheet/DeleteSettings.tsx
@@ -1,9 +1,13 @@
 import Button from "../Button";
 import BottomSheet from "./BottomSheet";
 
-const DeleteSettings = () => {
+interface DeleteSettingsProps {
+  onClose: () => void;
+}
+
+const DeleteSettings = ({ onClose }: DeleteSettingsProps) => {
   return (
-    <BottomSheet>
+    <BottomSheet onClose={onClose}>
       <div className="flex w-full flex-col gap-600 font-Binggrae text-body-2 font-regular text-gray-900">
         <div className="text-heading-2 font-regular">
           일기를 <span className="text-primary-medium">삭제</span>하시겠어요?

--- a/src/components/common/BottomSheet/DiaryContentSettings.stories.tsx
+++ b/src/components/common/BottomSheet/DiaryContentSettings.stories.tsx
@@ -11,5 +11,7 @@ export default meta;
 type Story = StoryObj<typeof DiaryContentSettings>;
 
 export const Primary: Story = {
-  args: {},
+  args: {
+    onClose: () => {},
+  },
 };

--- a/src/components/common/BottomSheet/DiaryContentSettings.tsx
+++ b/src/components/common/BottomSheet/DiaryContentSettings.tsx
@@ -7,6 +7,7 @@ import Toggle from "../Toggle";
 
 interface DiaryContentSettingsProps {
   onClose: () => void;
+  isChecked: boolean;
   onClickModify: () => void;
   onClickDelete: () => void;
   onChangeToggle: (isChecked: boolean) => void;
@@ -18,6 +19,7 @@ interface DiaryContentSettingsProps {
  */
 const DiaryContentSettings = ({
   onClose,
+  isChecked,
   onClickModify,
   onClickDelete,
   onChangeToggle,
@@ -28,9 +30,9 @@ const DiaryContentSettings = ({
         <div className="flex gap-500">
           <PeopleIcon />
           <span>공개 여부</span>
-          <span className="text-primary-medium">공개</span>
+          <span className="text-primary-medium">{isChecked ? "공개" : "비공개"}</span>
           <button className="ml-auto">
-            <Toggle onClickHandler={onChangeToggle} isChecked={true} />
+            <Toggle onClickHandler={onChangeToggle} isChecked={isChecked} />
           </button>
         </div>
         <Divider />

--- a/src/components/common/BottomSheet/DiaryContentSettings.tsx
+++ b/src/components/common/BottomSheet/DiaryContentSettings.tsx
@@ -3,22 +3,29 @@ import PeopleIcon from "../../../assets/svg/people.svg?react";
 import EditIcon from "../../../assets/svg/edit.svg?react";
 import DeleteIcon from "../../../assets/svg/delete.svg?react";
 import Divider from "../Divider";
+import { ReactNode } from "react";
+import Toggle from "../Toggle";
 
-//토글 버튼 구현해야 함
+interface DiaryContentSettingsProps {
+  children: ReactNode;
+  onClose: () => void;
+}
 
 /**
  * 일기 페이지 설정 버튼 누를 시 나오는 모달
  * @returns
  */
-const DiaryContentSettings = () => {
+const DiaryContentSettings = ({ onClose }: DiaryContentSettingsProps) => {
   return (
-    <BottomSheet>
+    <BottomSheet onClose={onClose}>
       <div className="flex w-full flex-col gap-600 font-Binggrae text-body-2 font-regular text-gray-700">
         <div className="flex gap-500">
           <PeopleIcon />
           <span>공개 여부</span>
           <span className="text-primary-medium">공개</span>
-          <button className="ml-auto">토글버튼</button>
+          <button className="ml-auto">
+            <Toggle onClickHandler={() => {}} isChecked={true} />
+          </button>
         </div>
         <Divider />
         <div className="flex h-full flex-col gap-900">

--- a/src/components/common/BottomSheet/DiaryContentSettings.tsx
+++ b/src/components/common/BottomSheet/DiaryContentSettings.tsx
@@ -3,19 +3,25 @@ import PeopleIcon from "../../../assets/svg/people.svg?react";
 import EditIcon from "../../../assets/svg/edit.svg?react";
 import DeleteIcon from "../../../assets/svg/delete.svg?react";
 import Divider from "../Divider";
-import { ReactNode } from "react";
 import Toggle from "../Toggle";
 
 interface DiaryContentSettingsProps {
-  children: ReactNode;
   onClose: () => void;
+  onClickModify: () => void;
+  onClickDelete: () => void;
+  onChangeToggle: (isChecked: boolean) => void;
 }
 
 /**
  * 일기 페이지 설정 버튼 누를 시 나오는 모달
  * @returns
  */
-const DiaryContentSettings = ({ onClose }: DiaryContentSettingsProps) => {
+const DiaryContentSettings = ({
+  onClose,
+  onClickModify,
+  onClickDelete,
+  onChangeToggle,
+}: DiaryContentSettingsProps) => {
   return (
     <BottomSheet onClose={onClose}>
       <div className="flex w-full flex-col gap-600 font-Binggrae text-body-2 font-regular text-gray-700">
@@ -24,16 +30,16 @@ const DiaryContentSettings = ({ onClose }: DiaryContentSettingsProps) => {
           <span>공개 여부</span>
           <span className="text-primary-medium">공개</span>
           <button className="ml-auto">
-            <Toggle onClickHandler={() => {}} isChecked={true} />
+            <Toggle onClickHandler={onChangeToggle} isChecked={true} />
           </button>
         </div>
         <Divider />
         <div className="flex h-full flex-col gap-900">
-          <button className="flex gap-500 text-start">
+          <button className="flex gap-500 text-start" onClick={onClickModify}>
             <EditIcon />
             <span>일기 수정하기</span>
           </button>
-          <button className="flex gap-500 text-start text-status-negative">
+          <button className="flex gap-500 text-start text-status-negative" onClick={onClickDelete}>
             <DeleteIcon />
             <span>일기 삭제하기</span>
           </button>

--- a/src/components/common/BottomSheet/DiaryImageSettings.stories.tsx
+++ b/src/components/common/BottomSheet/DiaryImageSettings.stories.tsx
@@ -11,5 +11,7 @@ export default meta;
 type Story = StoryObj<typeof DiaryImageSettings>;
 
 export const Primary: Story = {
-  args: {},
+  args: {
+    onClose: () => {},
+  },
 };

--- a/src/components/common/BottomSheet/DiaryImageSettings.tsx
+++ b/src/components/common/BottomSheet/DiaryImageSettings.tsx
@@ -4,13 +4,17 @@ import DeleteIcon from "../../../assets/svg/delete.svg?react";
 import StarIcon from "../../../assets/svg/star.svg?react";
 import DownloadIcon from "../../../assets/svg/download.svg?react";
 
+interface DiaryImageSettingsProps {
+  onClose: () => void;
+}
+
 /**
  * 일기 페이지 이미지 설정 시 나오는 모달
  * @returns
  */
-const DiaryImageSettings = () => {
+const DiaryImageSettings = ({ onClose }: DiaryImageSettingsProps) => {
   return (
-    <BottomSheet>
+    <BottomSheet onClose={onClose}>
       <div className="flex w-full flex-col gap-600 font-Binggrae text-body-2 font-regular text-gray-700">
         <div className="flex justify-center">
           <img src={testImg} alt="" width={176} height={308} />

--- a/src/components/common/Toggle.tsx
+++ b/src/components/common/Toggle.tsx
@@ -10,14 +10,7 @@ const Toggle = ({ onClickHandler, isChecked }: ToggleProps) => {
 
   return (
     <label className="inline-flex cursor-pointer items-center">
-      <input
-        type="checkbox"
-        className="peer sr-only"
-        checked={isChecked}
-        onClick={() => {
-          handleToggle();
-        }}
-      />
+      <input type="checkbox" className="peer sr-only" checked={isChecked} onChange={handleToggle} />
       <div className="peer relative h-[1.75rem] w-[3.25rem] rounded-full bg-gray-200 shadow-default after:absolute after:start-[2px] after:top-[2px] after:h-6 after:w-[1.48rem] after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:bg-primary-medium peer-checked:after:translate-x-full peer-checked:after:border-white rtl:peer-checked:after:-translate-x-full"></div>
     </label>
   );

--- a/src/components/pages/write/ReviewContent.stories.tsx
+++ b/src/components/pages/write/ReviewContent.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import dummy from "../../../assets/dummy/_Image.png";
+
+import ReviewContent from "./ReviewContent";
+
+const meta: Meta<typeof ReviewContent> = {
+  component: ReviewContent,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof ReviewContent>;
+
+export const Primary: Story = {
+  args: {
+    content: "일기 내용",
+    emotion: "happy",
+    likedCount: 5,
+    isLiked: true,
+    date: "2024-09-28",
+    images: [{ imageId: "1", imageUrl: dummy, isMain: true }],
+  },
+};

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentProps<"textarea">
+>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+})
+Textarea.displayName = "Textarea"
+
+export { Textarea }

--- a/src/index.css
+++ b/src/index.css
@@ -17,3 +17,68 @@
   src: url("./assets/fonts/Binggrae-Bold.otf") format("opentype");
   font-display: swap;
 }
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 0 0% 3.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 0 0% 3.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 0 0% 3.9%;
+    --primary: 0 0% 9%;
+    --primary-foreground: 0 0% 98%;
+    --secondary: 0 0% 96.1%;
+    --secondary-foreground: 0 0% 9%;
+    --muted: 0 0% 96.1%;
+    --muted-foreground: 0 0% 45.1%;
+    --accent: 0 0% 96.1%;
+    --accent-foreground: 0 0% 9%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 0 0% 89.8%;
+    --input: 0 0% 89.8%;
+    --ring: 0 0% 3.9%;
+    --chart-1: 12 76% 61%;
+    --chart-2: 173 58% 39%;
+    --chart-3: 197 37% 24%;
+    --chart-4: 43 74% 66%;
+    --chart-5: 27 87% 67%;
+    --radius: 0.5rem;
+  }
+  .dark {
+    --background: 0 0% 3.9%;
+    --foreground: 0 0% 98%;
+    --card: 0 0% 3.9%;
+    --card-foreground: 0 0% 98%;
+    --popover: 0 0% 3.9%;
+    --popover-foreground: 0 0% 98%;
+    --primary: 0 0% 98%;
+    --primary-foreground: 0 0% 9%;
+    --secondary: 0 0% 14.9%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 0 0% 14.9%;
+    --muted-foreground: 0 0% 63.9%;
+    --accent: 0 0% 14.9%;
+    --accent-foreground: 0 0% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 0 0% 14.9%;
+    --input: 0 0% 14.9%;
+    --ring: 0 0% 83.1%;
+    --chart-1: 220 70% 50%;
+    --chart-2: 160 60% 45%;
+    --chart-3: 30 80% 55%;
+    --chart-4: 280 65% 60%;
+    --chart-5: 340 75% 55%;
+  }
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/src/pages/diary/Diary.tsx
+++ b/src/pages/diary/Diary.tsx
@@ -5,6 +5,8 @@ import Appbar from "../../components/common/Appbar";
 import { formatDateWithWeek } from "../../utils/util";
 import { DiaryInfo } from "../../types/types";
 import RoutePaths from "../../constants/routePath";
+import { useState } from "react";
+import DiaryContentSettings from "../../components/common/BottomSheet/DiaryContentSettings";
 
 interface DiaryProps {
   diaryInfo: DiaryInfo;
@@ -19,6 +21,15 @@ interface DiaryProps {
 const Diary = ({ diaryInfo, carouselHeight, isMyDiary }: DiaryProps) => {
   const navigate = useNavigate();
   const location = useLocation();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleMenuClick = () => {
+    setIsModalOpen(true); // Open the modal
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false); // Close the modal
+  };
 
   return (
     <div className="h-screen overflow-scroll">
@@ -31,7 +42,7 @@ const Diary = ({ diaryInfo, carouselHeight, isMyDiary }: DiaryProps) => {
               navigate(-1);
             }
           }}
-          menuHandler={() => {}}
+          menuHandler={handleMenuClick}
         ></Appbar>
       </div>
 
@@ -48,6 +59,15 @@ const Diary = ({ diaryInfo, carouselHeight, isMyDiary }: DiaryProps) => {
           content={diaryInfo.content}
         />
       </div>
+      {isModalOpen && (
+        <DiaryContentSettings onClose={() => setIsModalOpen(false)}>
+          <div>
+            <h2>Modal Title</h2>
+            <p>This is the content of the modal.</p>
+            <button onClick={closeModal}>Close</button>
+          </div>
+        </DiaryContentSettings>
+      )}
     </div>
   );
 };

--- a/src/pages/diary/Diary.tsx
+++ b/src/pages/diary/Diary.tsx
@@ -41,19 +41,23 @@ const Diary = ({ diaryInfo, carouselHeight, isMyDiary }: DiaryProps) => {
   };
 
   const onChangeToggle = () => {
-    setIsPublic((prev) => !prev); // 토글 상태 업데이트
+    setIsPublic((prev) => {
+      const newIsPublic = !prev;
 
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-    }
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
 
-    timeoutRef.current = setTimeout(() => {
-      putModifiedDiary({
-        diaryId: diaryInfo.diaryId,
-        content: diaryInfo.content,
-        isPublic: !isPublic,
-      });
-    }, debounceDelay);
+      timeoutRef.current = setTimeout(() => {
+        putModifiedDiary({
+          diaryId: diaryInfo.diaryId,
+          content: diaryInfo.content,
+          isPublic: newIsPublic,
+        });
+      }, debounceDelay);
+
+      return newIsPublic;
+    });
   };
   const onClickModify = () => {
     navigate("modify", { state: { diaryInfo: diaryInfo } });

--- a/src/pages/diary/Diary.tsx
+++ b/src/pages/diary/Diary.tsx
@@ -7,7 +7,7 @@ import { DiaryInfo } from "../../types/types";
 import RoutePaths from "../../constants/routePath";
 import { useEffect, useRef, useState } from "react";
 import DiaryContentSettings from "../../components/common/BottomSheet/DiaryContentSettings";
-import { putModifiedDiary } from "@/api/api";
+import { deleteDiary, putModifiedDiary } from "@/api/api";
 
 interface DiaryProps {
   diaryInfo: DiaryInfo;
@@ -48,22 +48,34 @@ const Diary = ({ diaryInfo, carouselHeight, isMyDiary }: DiaryProps) => {
         clearTimeout(timeoutRef.current);
       }
 
-      timeoutRef.current = setTimeout(() => {
-        putModifiedDiary({
-          diaryId: diaryInfo.diaryId,
-          content: diaryInfo.content,
-          isPublic: newIsPublic,
-        });
+      timeoutRef.current = setTimeout(async () => {
+        try {
+          await putModifiedDiary({
+            diaryId: diaryInfo.diaryId,
+            content: diaryInfo.content,
+            isPublic: newIsPublic,
+          });
+        } catch (error) {
+          throw error;
+        }
       }, debounceDelay);
 
       return newIsPublic;
     });
   };
+
   const onClickModify = () => {
     navigate("modify", { state: { diaryInfo: diaryInfo } });
   };
 
-  const onClickDelete = () => {};
+  const onClickDelete = async () => {
+    try {
+      await deleteDiary(diaryInfo.diaryId);
+      navigate("/");
+    } catch (error) {
+      throw error;
+    }
+  };
 
   return (
     <div className="h-screen overflow-scroll">

--- a/src/pages/diary/Diary.tsx
+++ b/src/pages/diary/Diary.tsx
@@ -24,11 +24,7 @@ const Diary = ({ diaryInfo, carouselHeight, isMyDiary }: DiaryProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const handleMenuClick = () => {
-    setIsModalOpen(true); // Open the modal
-  };
-
-  const closeModal = () => {
-    setIsModalOpen(false); // Close the modal
+    setIsModalOpen(true);
   };
 
   return (
@@ -60,13 +56,14 @@ const Diary = ({ diaryInfo, carouselHeight, isMyDiary }: DiaryProps) => {
         />
       </div>
       {isModalOpen && (
-        <DiaryContentSettings onClose={() => setIsModalOpen(false)}>
-          <div>
-            <h2>Modal Title</h2>
-            <p>This is the content of the modal.</p>
-            <button onClick={closeModal}>Close</button>
-          </div>
-        </DiaryContentSettings>
+        <DiaryContentSettings
+          onClose={() => setIsModalOpen(false)}
+          onChangeToggle={() => {}}
+          onClickDelete={() => {}}
+          onClickModify={() => {
+            navigate("modify", { state: { diaryInfo: diaryInfo } });
+          }}
+        ></DiaryContentSettings>
       )}
     </div>
   );

--- a/src/pages/diary/Layout/DiaryLayout.tsx
+++ b/src/pages/diary/Layout/DiaryLayout.tsx
@@ -25,7 +25,9 @@ const DiaryLayout = () => {
       if (!diaryID) return;
       try {
         const data = await getDiaryInfoById(diaryID);
-        setIsMyDiary(false);
+        if (data.isMine) setIsMyDiary(true);
+        else setIsMyDiary(false);
+
         setDiaryInfo(data);
       } catch (error) {
         setDiaryInfo(null);

--- a/src/pages/write/Layout/DiaryModifyFlowLayout.tsx
+++ b/src/pages/write/Layout/DiaryModifyFlowLayout.tsx
@@ -1,0 +1,40 @@
+import { Outlet, useNavigate } from "react-router-dom";
+import Appbar from "../../../components/common/Appbar";
+import MobileLayout from "../../Layout/MobileLayout";
+import Button from "../../../components/common/Button";
+import { useState } from "react";
+import RoutePaths from "../../../constants/routePath";
+
+const modifyOrder = [RoutePaths.diaryWrite];
+const addImageOrder = [RoutePaths.diaryReview, RoutePaths.diaryDraw];
+
+const DiaryModifyFlowLayout = () => {
+  const navigate = useNavigate();
+  const [diaryInfo, setDiaryInfo] = useState({});
+
+  const onClickNext = async () => {};
+
+  const handleActive = () => {
+    return true;
+  };
+
+  return (
+    <MobileLayout>
+      <Appbar text="일기 수정" backHandler={() => navigate(-1)}></Appbar>
+      <div className="flex-grow overflow-scroll px-800 py-300">
+        <Outlet context={{ diaryInfo, setDiaryInfo }} />
+      </div>
+      <div className="my-4 flex justify-center">
+        <Button
+          size="big"
+          active={handleActive()}
+          text="다음으로"
+          onClickHandler={onClickNext}
+          bgColor="dark"
+        />
+      </div>
+    </MobileLayout>
+  );
+};
+
+export default DiaryModifyFlowLayout;

--- a/src/pages/write/Layout/DiaryModifyFlowLayout.tsx
+++ b/src/pages/write/Layout/DiaryModifyFlowLayout.tsx
@@ -28,7 +28,7 @@ const DiaryModifyFlowLayout = () => {
         <Button
           size="big"
           active={handleActive()}
-          text="다음으로"
+          text="수정 완료"
           onClickHandler={onClickNext}
           bgColor="dark"
         />

--- a/src/pages/write/Layout/DiaryModifyFlowLayout.tsx
+++ b/src/pages/write/Layout/DiaryModifyFlowLayout.tsx
@@ -3,10 +3,10 @@ import Appbar from "../../../components/common/Appbar";
 import MobileLayout from "../../Layout/MobileLayout";
 import Button from "../../../components/common/Button";
 import { useState } from "react";
-import RoutePaths from "../../../constants/routePath";
+// import RoutePaths from "../../../constants/routePath";
 
-const modifyOrder = [RoutePaths.diaryWrite];
-const addImageOrder = [RoutePaths.diaryReview, RoutePaths.diaryDraw];
+// const modifyOrder = [RoutePaths.diaryWrite];
+// const addImageOrder = [RoutePaths.diaryReview, RoutePaths.diaryDraw];
 
 const DiaryModifyFlowLayout = () => {
   const navigate = useNavigate();

--- a/src/pages/write/Modify.tsx
+++ b/src/pages/write/Modify.tsx
@@ -1,0 +1,59 @@
+import { useLocation, useNavigate } from "react-router-dom";
+import { formatDateWithWeek } from "../../utils/util";
+import { FADEINANIMATION } from "../../styles/animations";
+import { useEffect, useState } from "react";
+import Divider from "../../components/common/Divider";
+import { Textarea } from "@/components/ui/textarea";
+import Appbar from "@/components/common/Appbar";
+import MobileLayout from "../Layout/MobileLayout";
+import Button from "@/components/common/Button";
+import { DiaryInfo } from "@/types/types";
+
+const Modify = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [diaryInfo, setDiaryInfo] = useState<DiaryInfo | null>(null);
+
+  const onClickModify = () => {
+    //일기 수정
+  };
+
+  useEffect(() => {
+    setDiaryInfo(location.state.diaryInfo);
+  }, []);
+
+  return (
+    <MobileLayout>
+      <Appbar text="일기 수정" backHandler={() => navigate(-1)}></Appbar>
+      <div className="flex-grow overflow-scroll px-800 py-300">
+        {diaryInfo && (
+          <div className="flex h-full flex-col gap-600 font-Binggrae text-gray-900">
+            <div className={`${FADEINANIMATION[0]} font-BinggraeBold text-title-2`}>
+              {formatDateWithWeek(diaryInfo.date)}
+            </div>
+            <Divider style={FADEINANIMATION[1]} />
+            <Textarea
+              className={`${FADEINANIMATION[2]} flex-grow font-Binggrae text-body-2`}
+              value={diaryInfo.content}
+              onChange={(e) => {
+                setDiaryInfo({ ...diaryInfo, content: e.target.value });
+              }}
+              placeholder="10자 이상 입력해주세요"
+            ></Textarea>
+          </div>
+        )}
+      </div>
+      <div className="my-4 flex justify-center">
+        <Button
+          size="big"
+          active={true}
+          text="수정 완료"
+          onClickHandler={onClickModify}
+          bgColor="dark"
+        />
+      </div>
+    </MobileLayout>
+  );
+};
+
+export default Modify;

--- a/src/pages/write/Modify.tsx
+++ b/src/pages/write/Modify.tsx
@@ -8,14 +8,26 @@ import Appbar from "@/components/common/Appbar";
 import MobileLayout from "../Layout/MobileLayout";
 import Button from "@/components/common/Button";
 import { DiaryInfo } from "@/types/types";
+import { putModifiedDiary } from "@/api/api";
 
 const Modify = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const [diaryInfo, setDiaryInfo] = useState<DiaryInfo | null>(null);
 
-  const onClickModify = () => {
-    //일기 수정
+  const onClickModify = async () => {
+    if (diaryInfo) {
+      try {
+        await putModifiedDiary({
+          diaryId: diaryInfo.diaryId,
+          content: diaryInfo.content,
+          isPublic: diaryInfo.isPublic,
+        });
+      } catch (error) {
+        throw error;
+      }
+    }
+    navigate(-1);
   };
 
   useEffect(() => {

--- a/src/pages/write/Write.tsx
+++ b/src/pages/write/Write.tsx
@@ -5,6 +5,7 @@ import { FADEINANIMATION } from "../../styles/animations";
 import { useEffect } from "react";
 import Toggle from "../../components/common/Toggle";
 import Divider from "../../components/common/Divider";
+import { Textarea } from "@/components/ui/textarea";
 
 const Write = () => {
   const location = useLocation();
@@ -33,14 +34,14 @@ const Write = () => {
         </div>
       </div>
       <Divider style={FADEINANIMATION[2]} />
-      <textarea
+      <Textarea
         className={`${FADEINANIMATION[3]} flex-grow font-Binggrae text-body-2`}
         value={diaryInfo.content}
         onChange={(e) => {
           setDiaryInfo({ ...diaryInfo, content: e.target.value });
         }}
         placeholder="10자 이상 입력해주세요"
-      ></textarea>
+      ></Textarea>
     </div>
   );
 };

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -8,6 +8,8 @@ import DiaryWriteFlowLayout from "../pages/write/Layout/DiaryWriteFlowLayout";
 import { ErrorBoundary } from "react-error-boundary";
 import AlbumFallback from "../components/pages/album/fallback/AlbumFallback";
 import DiaryFallback from "../pages/diary/Fallback/DiaryFallback";
+import DiaryModifyFlowLayout from "@/pages/write/Layout/DiaryModifyFlowLayout";
+import Modify from "@/pages/write/Modify";
 
 const HomePage = lazy(() => import("../pages/Home"));
 const ExplorePage = lazy(() => import("../pages/Explore"));
@@ -79,7 +81,7 @@ const routes: RouteObject[] = [
     ),
   },
   {
-    path: RoutePaths.home,
+    path: RoutePaths.diary,
     element: (
       <ErrorBoundary FallbackComponent={ErrorPage}>
         <Suspense fallback={<GlobalFallback />}>
@@ -129,6 +131,42 @@ const routes: RouteObject[] = [
         <Login />
       </Suspense>
     ),
+  },
+  {
+    path: "/diary/:diaryID/modify",
+    element: (
+      <Suspense fallback={<PageFallback />}>
+        <Modify />
+      </Suspense>
+    ),
+  },
+  {
+    path: RoutePaths.diary,
+    element: (
+      <ErrorBoundary FallbackComponent={ErrorPage}>
+        <Suspense fallback={<GlobalFallback />}>
+          <DiaryModifyFlowLayout />
+        </Suspense>
+      </ErrorBoundary>
+    ),
+    children: [
+      {
+        path: "/diary/:diaryID/style",
+        element: (
+          <Suspense fallback={<PageFallback />}>
+            <Style />
+          </Suspense>
+        ),
+      },
+      {
+        path: "/diary/:diaryID/draw",
+        element: (
+          <Suspense fallback={<PageFallback />}>
+            <Draw />
+          </Suspense>
+        ),
+      },
+    ],
   },
 
   {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,96 +1,143 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
-  darkMode: "class",
+  darkMode: ["class", "class"],
   theme: {
-    extend: {
-      colors: {
-        gray: {
-          50: "#F6F6F6",
-          100: "#E7E7E7",
-          200: "#D1D1D1",
-          300: "#B0B0B0",
-          400: "#888888",
-          500: "#6D6D6D",
-          600: "#5D5D5D",
-          700: "#454545",
-          800: "#3D3D3D",
-          900: "#000000",
-        },
-        primary: {
-          "light-1": "#F9F5FF",
-          "light-2": "#F2E9FE",
-          "light-3": "#D4B6FC",
-          medium: "#A059F3",
-          normal: "#6424A5",
-        },
-        status: {
-          positive: "#00BF40",
-          negative: "#EB022B",
-        },
-        static: {
-          black: "#000000",
-          white: "#FFFFFF",
-          Background: "#FCFCFC",
-        },
-      },
-      borderRadius: {
-        50: "0.5rem",
-        100: "0.75rem",
-        200: "1rem",
-        300: "1.25rem",
-        400: "1.5rem",
-      },
-      boxShadow: {
-        default: "0 0.125rem 8px 0 rgba(0, 0, 0, 0.08)",
-      },
-      fontFamily: {
-        Binggrae: ["Binggrae"],
-        BinggraeBold: ["BinggraeBold"],
-        Pretendard: ["Pretendard"],
-      },
-      fontSize: {
-        "title-1": "1.5rem",
-        "title-2": "1.375rem",
-        "heading-1": "1.25rem",
-        "heading-2": "1.125rem",
-        "body-1": "1rem",
-        "body-2": "0.875rem",
-        "detail-1": "0.75rem",
-        "detail-2": "0.65rem",
-      },
-      fontWeight: {
-        bold: 700,
-        semibold: 600,
-        medium: 500,
-        regular: 400,
-      },
-      spacing: {
-        0: "0rem",
-        100: "0.125rem",
-        200: "0.25rem",
-        300: "0.5rem",
-        400: "0.625rem",
-        500: "0.75rem",
-        600: "1rem",
-        700: "1.25rem",
-        800: "1.5rem",
-        900: "1.75rem",
-        1000: "2rem",
-      },
-    },
-    keyframes: {
-      fadeInSlideUp: {
-        "0%": { opacity: "0", transform: "translateY(1rem)" },
-        "100%": { opacity: "1", transform: "translateY(0)" },
-      },
-    },
-    animation: {
-      fadeInSlideUp: "fadeInSlideUp 0.5s ease-out forwards",
-    },
-    backdropBlur: {
-      default: "25px",
-    },
+  	extend: {
+  		colors: {
+  			gray: {
+  				'50': '#F6F6F6',
+  				'100': '#E7E7E7',
+  				'200': '#D1D1D1',
+  				'300': '#B0B0B0',
+  				'400': '#888888',
+  				'500': '#6D6D6D',
+  				'600': '#5D5D5D',
+  				'700': '#454545',
+  				'800': '#3D3D3D',
+  				'900': '#000000'
+  			},
+  			primary: {
+  				'light-1': '#F9F5FF',
+  				'light-2': '#F2E9FE',
+  				'light-3': '#D4B6FC',
+  				medium: '#A059F3',
+  				normal: '#6424A5',
+  				DEFAULT: 'hsl(var(--primary))',
+  				foreground: 'hsl(var(--primary-foreground))'
+  			},
+  			status: {
+  				positive: '#00BF40',
+  				negative: '#EB022B'
+  			},
+  			static: {
+  				black: '#000000',
+  				white: '#FFFFFF',
+  				Background: '#FCFCFC'
+  			},
+  			background: 'hsl(var(--background))',
+  			foreground: 'hsl(var(--foreground))',
+  			card: {
+  				DEFAULT: 'hsl(var(--card))',
+  				foreground: 'hsl(var(--card-foreground))'
+  			},
+  			popover: {
+  				DEFAULT: 'hsl(var(--popover))',
+  				foreground: 'hsl(var(--popover-foreground))'
+  			},
+  			secondary: {
+  				DEFAULT: 'hsl(var(--secondary))',
+  				foreground: 'hsl(var(--secondary-foreground))'
+  			},
+  			muted: {
+  				DEFAULT: 'hsl(var(--muted))',
+  				foreground: 'hsl(var(--muted-foreground))'
+  			},
+  			accent: {
+  				DEFAULT: 'hsl(var(--accent))',
+  				foreground: 'hsl(var(--accent-foreground))'
+  			},
+  			destructive: {
+  				DEFAULT: 'hsl(var(--destructive))',
+  				foreground: 'hsl(var(--destructive-foreground))'
+  			},
+  			border: 'hsl(var(--border))',
+  			input: 'hsl(var(--input))',
+  			ring: 'hsl(var(--ring))',
+  			chart: {
+  				'1': 'hsl(var(--chart-1))',
+  				'2': 'hsl(var(--chart-2))',
+  				'3': 'hsl(var(--chart-3))',
+  				'4': 'hsl(var(--chart-4))',
+  				'5': 'hsl(var(--chart-5))'
+  			}
+  		},
+  		borderRadius: {
+  			'50': '0.5rem',
+  			'100': '0.75rem',
+  			'200': '1rem',
+  			'300': '1.25rem',
+  			'400': '1.5rem',
+  			lg: 'var(--radius)',
+  			md: 'calc(var(--radius) - 2px)',
+  			sm: 'calc(var(--radius) - 4px)'
+  		},
+  		boxShadow: {
+  			default: '0 0.125rem 8px 0 rgba(0, 0, 0, 0.08)'
+  		},
+  		fontFamily: {
+  			Binggrae: ["Binggrae"],
+  			BinggraeBold: ["BinggraeBold"],
+  			Pretendard: ["Pretendard"]
+  		},
+  		fontSize: {
+  			'title-1': '1.5rem',
+  			'title-2': '1.375rem',
+  			'heading-1': '1.25rem',
+  			'heading-2': '1.125rem',
+  			'body-1': '1rem',
+  			'body-2': '0.875rem',
+  			'detail-1': '0.75rem',
+  			'detail-2': '0.65rem'
+  		},
+  		fontWeight: {
+  			bold: '700',
+  			semibold: '600',
+  			medium: '500',
+  			regular: '400'
+  		},
+  		spacing: {
+  			'0': '0rem',
+  			'100': '0.125rem',
+  			'200': '0.25rem',
+  			'300': '0.5rem',
+  			'400': '0.625rem',
+  			'500': '0.75rem',
+  			'600': '1rem',
+  			'700': '1.25rem',
+  			'800': '1.5rem',
+  			'900': '1.75rem',
+  			'1000': '2rem'
+  		}
+  	},
+  	keyframes: {
+  		fadeInSlideUp: {
+  			'0%': {
+  				opacity: '0',
+  				transform: 'translateY(1rem)'
+  			},
+  			'100%': {
+  				opacity: '1',
+  				transform: 'translateY(0)'
+  			}
+  		}
+  	},
+  	animation: {
+  		fadeInSlideUp: 'fadeInSlideUp 0.5s ease-out forwards'
+  	},
+  	backdropBlur: {
+  		default: '25px'
+  	}
   },
   plugins: [
     function ({ addUtilities }) {
@@ -101,5 +148,6 @@ export default {
 
       addUtilities(animationDelays);
     },
-  ],
+      require("tailwindcss-animate")
+],
 };

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,6 +5,10 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
 
     /* Bundler mode */
     "moduleResolution": "bundler",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,12 @@
 {
   "files": [],
-  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
   // "compilerOptions": {
   //   "types": ["vite-plugin-svgr/client"]
   // },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,16 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import svgr from "vite-plugin-svgr";
+import path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [svgr(), react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
   build: {
     rollupOptions: {
       output: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1284,6 +1284,13 @@
   dependencies:
     undici-types "~6.19.2"
 
+"@types/node@^22.9.0":
+  version "22.9.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.9.0.tgz#b7f16e5c3384788542c72dc3d561a7ceae2c0365"
+  integrity sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==
+  dependencies:
+    undici-types "~6.19.8"
+
 "@types/prop-types@*":
   version "15.7.13"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.13.tgz#2af91918ee12d9d32914feb13f5326658461b451"
@@ -1965,6 +1972,23 @@ chromatic@^11.4.0:
   version "11.10.2"
   resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-11.10.2.tgz#e6e4aacebc67330e80b04bca8bb360a01e66d340"
   integrity sha512-EbVlhmOLGdx9QRX3RMOTF3UzoyC1aaXNRjlzm1mc++2OI5+6C5Bzwt2ZUYJ3Jnf/pJa23q0y5Y3QEDcfRVqIbg==
+
+class-variance-authority@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/class-variance-authority/-/class-variance-authority-0.7.0.tgz#1c3134d634d80271b1837452b06d821915954522"
+  integrity sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==
+  dependencies:
+    clsx "2.0.0"
+
+clsx@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.0.0.tgz#12658f3fd98fafe62075595a5c30e43d18f3d00b"
+  integrity sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==
+
+clsx@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -3659,6 +3683,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lucide-react@^0.456.0:
+  version "0.456.0"
+  resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.456.0.tgz#14906c3355cc65d3380b7b2294b331aeda1bb392"
+  integrity sha512-DIIGJqTT5X05sbAsQ+OhA8OtJYyD4NsEMCA/HQW/Y6ToPQ7gwbtujIoeAaup4HpHzV35SQOarKAWH8LYglB6eA==
+
 lz-string@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
@@ -4813,6 +4842,16 @@ synckit@^0.9.1:
     "@pkgr/core" "^0.1.0"
     tslib "^2.6.2"
 
+tailwind-merge@^2.5.4:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-2.5.4.tgz#4bf574e81fa061adeceba099ae4df56edcee78d1"
+  integrity sha512-0q8cfZHMu9nuYP/b5Shb7Y7Sh1B7Nnl5GqNr1U+n2p6+mybvRtayrQ+0042Z5byvTA8ihjlP8Odo8/VnHbZu4Q==
+
+tailwindcss-animate@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz#318b692c4c42676cc9e67b19b78775742388bef4"
+  integrity sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==
+
 tailwindcss@^3.4.12:
   version "3.4.12"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.4.12.tgz#fd3b67c6d2c04d9d7bfa13e3fc70ccef9fef0455"
@@ -5048,7 +5087,7 @@ unbox-primitive@^1.0.2:
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
 
-undici-types@~6.19.2:
+undici-types@~6.19.2, undici-types@~6.19.8:
   version "6.19.8"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==


### PR DESCRIPTION
## 이슈
- #40 
- #34 

## 구현 내용
- [x] 일기 조회 isMine 속성으로 변경
- [x] 일기 조회 설정창
- [x] shadcn 적용
- [x] 일기 공개 여부 수정
- [x] 일기 수정
- [x] 일기 삭제

## 상세 내용

## 고민한 내용
### 모달 구현 방식
- 일단 `isOpenModal` 상태로 관리하는 중
- 모달이 여러개가 떠야 하면 그만큼 상태도 많아지는게 맞는지 모르겠음
### 일기 수정 router
- 기존 `Write` 컴포넌트를 재활용하고자 했지만 레이아웃이 약간 다름
- `ModifyLayout`을 따로 만들기에는 한 페이지만 만들면 해결됨
- 같은 구조를 유지하는 것 보다는 한 페이지만 따로 만드는게 더 직관적이고 구조가 쉽다고 생각함
### 일기 조회 시 내 일기 조회/ 남의 일기 조회 api가 따로 있는 경우의 처리
- 일관성이 없어서 문제가 발생함
- type=my 로 파라미터를 추가했지만 이후 수정 화면을 /modify로 경로를 주고자 했는데 불가능함
- 어떻게 하는게 가장 좋은 방법일지 고민함..