### PR TITLE
fix: carouselHeight 값을 state로 관리

### DIFF
--- a/src/pages/diary/Diary.tsx
+++ b/src/pages/diary/Diary.tsx
@@ -49,9 +49,9 @@ const Diary = ({ diaryInfo, carouselHeight, isMyDiary }: DiaryProps) => {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [isPublic, setIsPublic] = useState(diaryInfo.isPublic);
   const [selectedImage, setSelectedImage] = useState<DiaryImage | null>(null);
+  const [currentHeight] = useState(carouselHeight - 50);
 
   useEffect(() => {
-    console.log(carouselHeight); //임시
     return () => {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
@@ -150,7 +150,7 @@ const Diary = ({ diaryInfo, carouselHeight, isMyDiary }: DiaryProps) => {
             "flex w-fit justify-center rounded-full border-none bg-primary-normal px-600 py-300 font-Binggrae text-body-2 text-white",
         }}
       />
-      <div className="absolute top-0 z-50 w-full">
+      <div className="fixed top-0 z-50 w-full">
         <Appbar
           backHandler={() => {
             if (location.state?.from === RoutePaths.diaryDraw) {
@@ -164,21 +164,19 @@ const Diary = ({ diaryInfo, carouselHeight, isMyDiary }: DiaryProps) => {
           menuHandler={isMyDiary ? handleMenuClick : undefined}
         />
       </div>
-      <div className="absolute top-0">
+      <div className="fixed top-0">
         <ImageCarousel images={diaryInfo.images} canAdd={isMyDiary} onLongPress={handleLongPress} />
       </div>
 
-      <div className="flex h-full flex-col overflow-scroll">
-        <div style={{ height: 580 }} className="flex-shrink-0"></div>
-        <div className="z-20 flex-grow">
-          <Content
-            date={formatDateWithWeek(diaryInfo.date)}
-            emotion={diaryInfo.emotion}
-            likedCount={diaryInfo.likedCount}
-            isLiked={diaryInfo.isLiked}
-            content={diaryInfo.content}
-          />
-        </div>
+      <div className={`flex-shrink-0`} style={{ height: currentHeight }}></div>
+      <div className="z-20 flex-grow">
+        <Content
+          date={formatDateWithWeek(diaryInfo.date)}
+          emotion={diaryInfo.emotion}
+          likedCount={diaryInfo.likedCount}
+          isLiked={diaryInfo.isLiked}
+          content={diaryInfo.content}
+        />
       </div>
 
       <BottomSheet


### PR DESCRIPTION
## 원인
`carouselHeight -50`을 인라인 스타일 안에서 계산하고 있었는데 `carouselHeight` 값에 문제가 발생한다는 것을 파악함

## 해결 과정
- overflow scroll 제거해봄
- fixed에 translateZ 속성 추가해봄
- fixed를 전부 absolute로 변경해봄
- 높이에 고정값을 주었을 때 문제 발생하지 않아 carouselHeight의 문제라고 판단함
- 처음 렌더링 당시에는 문제가 없고 스크롤을 하다 보면 발생하는 문제 => 초기 렌더링 값을 저장하자!
- 초기 렌더링시의 carouselHeight 값을 state로 저장해서 해결하였음