### PR TITLE
Feature: 홈 화면 달력 렌더링 로직, 오늘 일기 작성 버튼 제어

### DIFF
--- a/src/components/pages/home/Calendar.tsx
+++ b/src/components/pages/home/Calendar.tsx
@@ -76,6 +76,8 @@ const Calendar = ({
         month === new Date().getMonth() &&
         day === new Date().getDate();
 
+      const isSunday = new Date(year, month, day).getDay() === 0;
+
       const matchingDiary = calendarData.diaries.find(
         (diary) =>
           diary.date ===
@@ -90,11 +92,12 @@ const Calendar = ({
         emotion: matchingDiary ? matchingDiary.emotion : "none",
         calendarIcon: matchingDiary ? emotionImages[matchingDiary.emotion] : emotionImages.default,
         isToday: isToday,
+        isSunday: isSunday,
       };
 
       days.push(
         <CalendarDate
-          key={`${year}-${month}-${day}`}
+          key={calendarDataInfo.diaryId}
           onClickDate={onClickDate}
           calendarDataInfo={calendarDataInfo}
         />
@@ -123,7 +126,7 @@ const Calendar = ({
           <div className="flex justify-center py-[0.625rem]" key={index}>
             <div
               key={day}
-              className="flex h-8 w-10 items-center justify-center rounded-full bg-primary-light-2 font-Pretendard text-body-1 font-semibold text-primary-normal"
+              className={`flex h-8 w-10 items-center justify-center rounded-full bg-primary-light-2 font-Pretendard text-body-1 font-semibold text-primary-normal ${day === "일" ? "text-status-negative" : "text-primary-normal"}`}
             >
               {day}
             </div>

--- a/src/components/pages/home/Calendar.tsx
+++ b/src/components/pages/home/Calendar.tsx
@@ -12,6 +12,7 @@ import shy from "../../../assets/icon/shy.png";
 import surprised from "../../../assets/icon/surprised.png";
 import wonder from "../../../assets/icon/wonder.png";
 import { Diaries } from "../../../types/types";
+import CalendarDate from "./CalendarDate";
 
 const emotionImages: { [key: string]: string } = {
   JOY: happy,
@@ -53,19 +54,11 @@ const Calendar = ({
   const [calendarDays, setCalendarDays] = useState<ReactNode[]>([]);
 
   useEffect(() => {
-    const temp = calendarData.diaries.reduce(
-      (acc, diary) => {
-        const day = new Date(diary.date).getDate();
-        acc[day] = { id: diary.diaryId, emotion: diary.emotion };
-        return acc;
-      },
-      {} as { [day: number]: { id: string; emotion: string } }
-    );
+    const calendar = generateCalendar(currentDate.getFullYear(), currentDate.getMonth());
+    setCalendarDays(calendar);
+  }, [calendarData, currentDate]);
 
-    generateCalendar(currentDate.getFullYear(), currentDate.getMonth(), temp);
-  }, [calendarData]);
-
-  const generateCalendar = (year: number, month: number, temp: any) => {
+  const generateCalendar = (year: number, month: number) => {
     const firstDayOfMonth = new Date(year, month, 1);
     const daysInMonth = new Date(year, month + 1, 0).getDate();
     const firstDayOfWeek = firstDayOfMonth.getDay();
@@ -83,33 +76,32 @@ const Calendar = ({
         month === new Date().getMonth() &&
         day === new Date().getDate();
 
-      const diary = temp[day];
-      const emotionImage = diary ? emotionImages[diary.emotion] : emotionImages.default;
-      const id = diary ? diary.id : `${year}-${month + 1}-${String(day).padStart(2, "0")}`;
+      const matchingDiary = calendarData.diaries.find(
+        (diary) =>
+          diary.date ===
+          `${year}-${String(month + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`
+      );
+
+      const calendarDataInfo = {
+        date: day,
+        diaryId: matchingDiary
+          ? matchingDiary.diaryId
+          : `${year}-${month + 1}-${String(day).padStart(2, "0")}`,
+        emotion: matchingDiary ? matchingDiary.emotion : "none",
+        calendarIcon: matchingDiary ? emotionImages[matchingDiary.emotion] : emotionImages.default,
+        isToday: isToday,
+      };
 
       days.push(
-        <div
-          key={day}
-          className={`flex cursor-pointer flex-col items-center gap-300`}
-          onClick={() => handleDayClick(id)}
-        >
-          <div className="flex h-11 w-11 items-center justify-center rounded-100">
-            <img src={emotionImage} alt={diary ? diary.emotion : "null"} />
-          </div>
-          <div
-            className={`text-center text-detail-1 font-regular ${isToday && "w-10 rounded-300 bg-primary-normal font-BinggraeBold text-white"}`}
-          >
-            {day}
-          </div>
-        </div>
+        <CalendarDate
+          key={`${year}-${month}-${day}`}
+          onClickDate={onClickDate}
+          calendarDataInfo={calendarDataInfo}
+        />
       );
     }
 
-    setCalendarDays(days);
-  };
-
-  const handleDayClick = (id: string) => {
-    onClickDate(id);
+    return days;
   };
 
   return (

--- a/src/components/pages/home/CalendarDate.tsx
+++ b/src/components/pages/home/CalendarDate.tsx
@@ -1,0 +1,31 @@
+interface CalendarDateProps {
+  onClickDate: (id: string) => void;
+  calendarDataInfo: {
+    date: number;
+    diaryId: string;
+    emotion: string;
+    calendarIcon: string;
+    isToday: boolean;
+  };
+}
+
+const CalendarDate = ({ onClickDate, calendarDataInfo }: CalendarDateProps) => {
+  return (
+    <div
+      className="flex cursor-pointer flex-col items-center gap-300"
+      onClick={() => onClickDate(calendarDataInfo.diaryId)}
+    >
+      <div className="relative flex h-11 w-11 items-center justify-center rounded-100">
+        <img src={calendarDataInfo.calendarIcon} alt={calendarDataInfo.emotion} />
+      </div>
+
+      <div
+        className={`text-center text-detail-1 font-regular ${calendarDataInfo.isToday && "w-10 rounded-300 bg-primary-normal font-BinggraeBold text-white"}`}
+      >
+        {calendarDataInfo.date}
+      </div>
+    </div>
+  );
+};
+
+export default CalendarDate;

--- a/src/components/pages/home/CalendarDate.tsx
+++ b/src/components/pages/home/CalendarDate.tsx
@@ -6,6 +6,7 @@ interface CalendarDateProps {
     emotion: string;
     calendarIcon: string;
     isToday: boolean;
+    isSunday: boolean;
   };
 }
 
@@ -16,11 +17,15 @@ const CalendarDate = ({ onClickDate, calendarDataInfo }: CalendarDateProps) => {
       onClick={() => onClickDate(calendarDataInfo.diaryId)}
     >
       <div className="relative flex h-11 w-11 items-center justify-center rounded-100">
-        <img src={calendarDataInfo.calendarIcon} alt={calendarDataInfo.emotion} />
+        <img
+          src={calendarDataInfo.calendarIcon}
+          alt={calendarDataInfo.emotion}
+          className="animate-fadeIn"
+        />
       </div>
 
       <div
-        className={`text-center text-detail-1 font-regular ${calendarDataInfo.isToday && "w-10 rounded-300 bg-primary-normal font-BinggraeBold text-white"}`}
+        className={`text-center font-Binggrae text-detail-1 ${calendarDataInfo.isSunday && "text-status-negative"} ${calendarDataInfo.isToday && "w-10 rounded-300 bg-primary-normal font-BinggraeBold text-white"}`}
       >
         {calendarDataInfo.date}
       </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -14,6 +14,7 @@ import { Diaries } from "../types/types";
 const Home = () => {
   const [calendarData, setCalendarData] = useState<Diaries>({ diaries: [] });
   const [currentDate, setCurrentDate] = useState(new Date());
+  const [activeToday, setActiveToday] = useState(true);
   const navigate = useNavigate();
   const onClickCreateDiary = () => {
     navigate(RoutePaths.diaryWrite, { state: { date: getTodayDate() } });
@@ -47,7 +48,15 @@ const Home = () => {
   useEffect(() => {
     const calendarInit = async (currentDate: Date) => {
       const diaries = await getMonthlyDiariesByDate(formatDate(currentDate));
+
+      const active = diaries.diaries.some(
+        (diary) =>
+          diary.date ===
+          `${currentDate.getFullYear()}-${String(currentDate.getMonth() + 1).padStart(2, "0")}-${String(currentDate.getDate()).padStart(2, "0")}`
+      );
+
       setCalendarData(diaries);
+      setActiveToday(!active);
     };
 
     calendarInit(new Date());
@@ -88,7 +97,7 @@ const Home = () => {
       <div className="my-4 flex justify-center">
         <Button
           size="big"
-          active={true}
+          active={activeToday}
           text="오늘 일기 작성하기"
           onClickHandler={onClickCreateDiary}
           bgColor="dark"

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -23,10 +23,15 @@ const Home = () => {
     navigate(`${RoutePaths.diary}/${id}`);
   };
 
+  const updateCalander = async (currentDate: Date) => {
+    const diaries = await getMonthlyDiariesByDate(formatDate(currentDate));
+    setCalendarData(diaries);
+  };
+
   const handlePrevMonth = () => {
     setCurrentDate((prev) => {
       const prevMonth = new Date(prev.getFullYear(), prev.getMonth() - 1, 1);
-      calendarInit(prevMonth);
+      updateCalander(prevMonth);
       return prevMonth;
     });
   };
@@ -34,17 +39,17 @@ const Home = () => {
   const handleNextMonth = () => {
     setCurrentDate((prev) => {
       const nextMonth = new Date(prev.getFullYear(), prev.getMonth() + 1, 1);
-      calendarInit(nextMonth);
+      updateCalander(nextMonth);
       return nextMonth;
     });
   };
 
-  const calendarInit = async (currentDate: Date) => {
-    const diaries = await getMonthlyDiariesByDate(formatDate(currentDate));
-    setCalendarData(diaries);
-  };
-
   useEffect(() => {
+    const calendarInit = async (currentDate: Date) => {
+      const diaries = await getMonthlyDiariesByDate(formatDate(currentDate));
+      setCalendarData(diaries);
+    };
+
     calendarInit(new Date());
   }, []);
 
@@ -68,7 +73,7 @@ const Home = () => {
       }
     }
 
-    calendarInit(new Date());
+    updateCalander(new Date());
   }, [navigate]);
 
   return (

--- a/src/pages/diary/Diary.tsx
+++ b/src/pages/diary/Diary.tsx
@@ -53,7 +53,6 @@ const Diary = ({ diaryInfo, carouselHeight, isMyDiary, retry }: DiaryProps) => {
   const [currentHeight] = useState(carouselHeight - 50);
 
   useEffect(() => {
-    console.log(retry);
     return () => {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);

--- a/src/pages/diary/Layout/DiaryLayout.tsx
+++ b/src/pages/diary/Layout/DiaryLayout.tsx
@@ -7,6 +7,7 @@ import NoDiary from "../NoDiary";
 import MobileLayout from "../../Layout/MobileLayout";
 import DiaryFallback from "../Fallback/DiaryFallback";
 import useMediaQuery from "../../../hooks/useMediaQuery";
+import { isValidDate } from "@/utils/util";
 
 /**
  * 일기 화면 레이아웃
@@ -37,7 +38,8 @@ const DiaryLayout = () => {
   };
 
   useEffect(() => {
-    fetchDiary();
+    if (!isValidDate(diaryID!)) fetchDiary();
+    else setLoading(false);
   }, []);
 
   return (

--- a/src/utils/util.tsx
+++ b/src/utils/util.tsx
@@ -78,3 +78,13 @@ export const downloadFile = async (url: string, fileName?: string) => {
   a.click();
   document.body.removeChild(a);
 };
+
+/**
+ * 날짜 형식 검사 yyyy-mm-dd
+ * @param dateStr
+ * @returns
+ */
+export const isValidDate = (dateStr: string) => {
+  const regex = /^\d{4}-\d{2}-\d{2}$/;
+  return regex.test(dateStr);
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,141 +3,150 @@ export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   darkMode: ["class", "class"],
   theme: {
-  	extend: {
-  		colors: {
-  			gray: {
-  				'50': '#F6F6F6',
-  				'100': '#E7E7E7',
-  				'200': '#D1D1D1',
-  				'300': '#B0B0B0',
-  				'400': '#888888',
-  				'500': '#6D6D6D',
-  				'600': '#5D5D5D',
-  				'700': '#454545',
-  				'800': '#3D3D3D',
-  				'900': '#000000'
-  			},
-  			primary: {
-  				'light-1': '#F9F5FF',
-  				'light-2': '#F2E9FE',
-  				'light-3': '#D4B6FC',
-  				medium: '#A059F3',
-  				normal: '#6424A5',
-  				DEFAULT: 'hsl(var(--primary))',
-  				foreground: 'hsl(var(--primary-foreground))'
-  			},
-  			status: {
-  				positive: '#00BF40',
-  				negative: '#EB022B'
-  			},
-  			static: {
-  				black: '#000000',
-  				white: '#FFFFFF',
-  				Background: '#FCFCFC'
-  			},
-  			background: 'hsl(var(--background))',
-  			foreground: 'hsl(var(--foreground))',
-  			card: {
-  				DEFAULT: 'hsl(var(--card))',
-  				foreground: 'hsl(var(--card-foreground))'
-  			},
-  			popover: {
-  				DEFAULT: 'hsl(var(--popover))',
-  				foreground: 'hsl(var(--popover-foreground))'
-  			},
-  			secondary: {
-  				DEFAULT: 'hsl(var(--secondary))',
-  				foreground: 'hsl(var(--secondary-foreground))'
-  			},
-  			muted: {
-  				DEFAULT: 'hsl(var(--muted))',
-  				foreground: 'hsl(var(--muted-foreground))'
-  			},
-  			accent: {
-  				DEFAULT: 'hsl(var(--accent))',
-  				foreground: 'hsl(var(--accent-foreground))'
-  			},
-  			destructive: {
-  				DEFAULT: 'hsl(var(--destructive))',
-  				foreground: 'hsl(var(--destructive-foreground))'
-  			},
-  			border: 'hsl(var(--border))',
-  			input: 'hsl(var(--input))',
-  			ring: 'hsl(var(--ring))',
-  			chart: {
-  				'1': 'hsl(var(--chart-1))',
-  				'2': 'hsl(var(--chart-2))',
-  				'3': 'hsl(var(--chart-3))',
-  				'4': 'hsl(var(--chart-4))',
-  				'5': 'hsl(var(--chart-5))'
-  			}
-  		},
-  		borderRadius: {
-  			'50': '0.5rem',
-  			'100': '0.75rem',
-  			'200': '1rem',
-  			'300': '1.25rem',
-  			'400': '1.5rem',
-  			lg: 'var(--radius)',
-  			md: 'calc(var(--radius) - 2px)',
-  			sm: 'calc(var(--radius) - 4px)'
-  		},
-  		boxShadow: {
-  			default: '0 0.125rem 8px 0 rgba(0, 0, 0, 0.08)'
-  		},
-  		fontFamily: {
-  			Binggrae: ["Binggrae"],
-  			BinggraeBold: ["BinggraeBold"],
-  			Pretendard: ["Pretendard"]
-  		},
-  		fontSize: {
-  			'title-1': '1.5rem',
-  			'title-2': '1.375rem',
-  			'heading-1': '1.25rem',
-  			'heading-2': '1.125rem',
-  			'body-1': '1rem',
-  			'body-2': '0.875rem',
-  			'detail-1': '0.75rem',
-  			'detail-2': '0.65rem'
-  		},
-  		fontWeight: {
-  			bold: '700',
-  			semibold: '600',
-  			medium: '500',
-  			regular: '400'
-  		},
-  		spacing: {
-  			'0': '0rem',
-  			'100': '0.125rem',
-  			'200': '0.25rem',
-  			'300': '0.5rem',
-  			'400': '0.625rem',
-  			'500': '0.75rem',
-  			'600': '1rem',
-  			'700': '1.25rem',
-  			'800': '1.5rem',
-  			'900': '1.75rem',
-  			'1000': '2rem'
-  		}
-  	},
-  	keyframes: {
-  		fadeInSlideUp: {
-  			'0%': {
-  				opacity: '0',
-  				transform: 'translateY(1rem)'
-  			},
-  			'100%': {
-  				opacity: '1',
-  				transform: 'translateY(0)'
-  			}
-  		}
-  	},
-  	animation: {
-  		fadeInSlideUp: 'fadeInSlideUp 0.5s ease-out forwards'
-  	},
-  	backdropBlur: {
-  		default: '25px'
-  	}
+    extend: {
+      colors: {
+        gray: {
+          50: "#F6F6F6",
+          100: "#E7E7E7",
+          200: "#D1D1D1",
+          300: "#B0B0B0",
+          400: "#888888",
+          500: "#6D6D6D",
+          600: "#5D5D5D",
+          700: "#454545",
+          800: "#3D3D3D",
+          900: "#000000",
+        },
+        primary: {
+          "light-1": "#F9F5FF",
+          "light-2": "#F2E9FE",
+          "light-3": "#D4B6FC",
+          medium: "#A059F3",
+          normal: "#6424A5",
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        status: {
+          positive: "#00BF40",
+          negative: "#EB022B",
+        },
+        static: {
+          black: "#000000",
+          white: "#FFFFFF",
+          Background: "#FCFCFC",
+        },
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        chart: {
+          1: "hsl(var(--chart-1))",
+          2: "hsl(var(--chart-2))",
+          3: "hsl(var(--chart-3))",
+          4: "hsl(var(--chart-4))",
+          5: "hsl(var(--chart-5))",
+        },
+      },
+      borderRadius: {
+        50: "0.5rem",
+        100: "0.75rem",
+        200: "1rem",
+        300: "1.25rem",
+        400: "1.5rem",
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+      boxShadow: {
+        default: "0 0.125rem 8px 0 rgba(0, 0, 0, 0.08)",
+      },
+      fontFamily: {
+        Binggrae: ["Binggrae"],
+        BinggraeBold: ["BinggraeBold"],
+        Pretendard: ["Pretendard"],
+      },
+      fontSize: {
+        "title-1": "1.5rem",
+        "title-2": "1.375rem",
+        "heading-1": "1.25rem",
+        "heading-2": "1.125rem",
+        "body-1": "1rem",
+        "body-2": "0.875rem",
+        "detail-1": "0.75rem",
+        "detail-2": "0.65rem",
+      },
+      fontWeight: {
+        bold: "700",
+        semibold: "600",
+        medium: "500",
+        regular: "400",
+      },
+      spacing: {
+        0: "0rem",
+        100: "0.125rem",
+        200: "0.25rem",
+        300: "0.5rem",
+        400: "0.625rem",
+        500: "0.75rem",
+        600: "1rem",
+        700: "1.25rem",
+        800: "1.5rem",
+        900: "1.75rem",
+        1000: "2rem",
+      },
+    },
+    keyframes: {
+      fadeInSlideUp: {
+        "0%": {
+          opacity: "0",
+          transform: "translateY(1rem)",
+        },
+        "100%": {
+          opacity: "1",
+          transform: "translateY(0)",
+        },
+      },
+      fadeIn: {
+        "0%": {
+          opacity: "0",
+        },
+        "100%": {
+          opacity: "1",
+        },
+      },
+    },
+    animation: {
+      fadeInSlideUp: "fadeInSlideUp 0.5s ease-out forwards",
+      fadeIn: "fadeIn 0.5s ease-out forwards",
+    },
+    backdropBlur: {
+      default: "25px",
+    },
   },
   plugins: [
     function ({ addUtilities }) {
@@ -148,6 +157,6 @@ export default {
 
       addUtilities(animationDelays);
     },
-      require("tailwindcss-animate")
-],
+    require("tailwindcss-animate"),
+  ],
 };


### PR DESCRIPTION
## 이슈
- #33 

## 구현 내용
- [x] 없는 일기 요청 방지
- [x] 오늘 일기 작성 비활성화 로직
- [x] 달력 날짜 컴포넌트 분리

## 상세 내용
![image](https://github.com/user-attachments/assets/840b2faa-119d-44e2-9732-938111680b81)
![image](https://github.com/user-attachments/assets/58736cdc-c1b1-4cd2-8d97-28c85571b735)

## 고민한 내용
### 달력 월 이동 시 지연, 잔상
- 기존에는 `calendarData`가 업데이트 되어야 달력에 반영이 되었음
- 이 때문에 `data`는 그대로인데 월이 변경되어서 이전 달의 정보가 다른 달에 보여지며 잔상이 생김
- 또한, 데이터 가져오는 동안 달력이 이동하지 않는게 UX적으로 좋지 않다고 판단함
- `generateCalendar` 함수 리팩토링하고 `currentDate`가 변경되면 달력을 업데이트
- 이를 통해 `currentDate`가 업데이트 되면 일기 정보가 없는 껍데기 달력이 렌더링되고 이후 `calendarData` 를 가져오는데 성공하면 일기 데이터를 표시, 이때 자연스럽게 등장하기 위해 `fadeIn`도 추가해봄