### PR TITLE
Feature: 통계 페이지 표 레이아웃

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.2",
+    "@radix-ui/react-tabs": "^1.1.1",
     "@tanstack/react-query": "^5.59.20",
     "autoprefixer": "^10.4.20",
     "axios": "^1.7.7",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-dom": "^18.3.1",
     "react-error-boundary": "^4.1.2",
     "react-router-dom": "^6.26.2",
+    "recharts": "^2.13.3",
     "sonner": "^1.7.0",
     "tailwind-merge": "^2.5.4",
     "tailwindcss": "^3.4.12",

--- a/src/components/common/Navbar.tsx
+++ b/src/components/common/Navbar.tsx
@@ -25,7 +25,10 @@ const Navbar = ({ NavList }: NavBarProps) => {
           <li
             key={element.label}
             className={`w-[4.375rem] ${
-              currentPath === element.path ? "text-primary-normal" : "text-gray-100"
+              currentPath === element.path ||
+              (element.path !== "/" && currentPath.startsWith(element.path))
+                ? "text-primary-normal"
+                : "text-gray-100"
             }`}
           >
             <Link to={element.path} className="flex flex-col items-center justify-center gap-200">

--- a/src/components/pages/stats/EmotionBarChart.tsx
+++ b/src/components/pages/stats/EmotionBarChart.tsx
@@ -10,12 +10,6 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart";
 
-const EmotionBarChart = () => {
-  return <Component></Component>;
-};
-
-export default EmotionBarChart;
-
 const chartData = [
   { month: "January", positive: 1, neutral: 3, negative: 2 },
   { month: "February", positive: 1, neutral: 1, negative: 4 },
@@ -39,7 +33,7 @@ const chartConfig = {
   },
 } satisfies ChartConfig;
 
-export function Component() {
+const EmotionBarChart = () => {
   return (
     <Card>
       <CardContent>
@@ -76,4 +70,6 @@ export function Component() {
       </CardContent>
     </Card>
   );
-}
+};
+
+export default EmotionBarChart;

--- a/src/components/pages/stats/EmotionBarChart.tsx
+++ b/src/components/pages/stats/EmotionBarChart.tsx
@@ -1,0 +1,72 @@
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
+
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+
+const EmotionBarChart = () => {
+  return <Component></Component>;
+};
+
+export default EmotionBarChart;
+
+const chartData = [
+  { month: "January", positive: 1, neutral: 3, negative: 2 },
+  { month: "February", positive: 1, neutral: 1, negative: 4 },
+  { month: "March", positive: 2, neutral: 2, negative: 3 },
+  { month: "April", positive: 1, neutral: 1, negative: 0 },
+  { month: "May", positive: 2, neutral: 4, negative: 1 },
+  { month: "June", positive: 3, neutral: 1, negative: 2 },
+];
+const chartConfig = {
+  positive: {
+    label: "positive",
+    color: "hsl(var(--chart-1))",
+  },
+  negative: {
+    label: "negative",
+    color: "hsl(var(--chart-2))",
+  },
+  neutral: {
+    label: "neutral",
+    color: "hsl(var(--chart-3))",
+  },
+} satisfies ChartConfig;
+
+export function Component() {
+  return (
+    <Card>
+      <CardContent>
+        <ChartContainer config={chartConfig} className="min-h-80 w-full">
+          <BarChart accessibilityLayer data={chartData}>
+            <CartesianGrid vertical={false} />
+            <XAxis
+              dataKey="month"
+              tickLine={false}
+              tickMargin={10}
+              axisLine={false}
+              tickFormatter={(value) => value.slice(0, 3)}
+            />
+            <YAxis tickLine={false} axisLine={false} width={12} />
+            <ChartTooltip content={<ChartTooltipContent />} trigger="click" />
+            <ChartLegend content={<ChartLegendContent />} />
+            <Bar
+              dataKey="positive"
+              stackId="a"
+              fill="var(--color-positive)"
+              radius={[0, 0, 4, 4]}
+            />
+            <Bar dataKey="negative" stackId="a" fill="var(--color-negative)" />
+            <Bar dataKey="neutral" stackId="a" fill="var(--color-neutral)" radius={[4, 4, 0, 0]} />
+          </BarChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/pages/stats/EmotionBarChart.tsx
+++ b/src/components/pages/stats/EmotionBarChart.tsx
@@ -26,16 +26,16 @@ const chartData = [
 ];
 const chartConfig = {
   positive: {
-    label: "positive",
-    color: "hsl(var(--chart-1))",
+    label: "긍정",
+    color: "#1FD18C",
   },
   negative: {
-    label: "negative",
-    color: "hsl(var(--chart-2))",
+    label: "부정",
+    color: "#E85E5D",
   },
   neutral: {
-    label: "neutral",
-    color: "hsl(var(--chart-3))",
+    label: "중립",
+    color: "#64ACF3",
   },
 } satisfies ChartConfig;
 

--- a/src/components/pages/stats/EmotionBarChart.tsx
+++ b/src/components/pages/stats/EmotionBarChart.tsx
@@ -10,14 +10,10 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart";
 
-const chartData = [
-  { month: "January", positive: 1, neutral: 3, negative: 2 },
-  { month: "February", positive: 1, neutral: 1, negative: 4 },
-  { month: "March", positive: 2, neutral: 2, negative: 3 },
-  { month: "April", positive: 1, neutral: 1, negative: 0 },
-  { month: "May", positive: 2, neutral: 4, negative: 1 },
-  { month: "June", positive: 3, neutral: 1, negative: 2 },
-];
+interface EmotionBarChartProps {
+  chartData: { dataKey: string; positive: number; negative: number; neutral: number }[];
+}
+
 const chartConfig = {
   positive: {
     label: "긍정",
@@ -33,7 +29,7 @@ const chartConfig = {
   },
 } satisfies ChartConfig;
 
-const EmotionBarChart = () => {
+const EmotionBarChart = ({ chartData }: EmotionBarChartProps) => {
   return (
     <Card>
       <CardContent>
@@ -41,13 +37,13 @@ const EmotionBarChart = () => {
           <BarChart accessibilityLayer data={chartData}>
             <CartesianGrid vertical={false} />
             <XAxis
-              dataKey="month"
+              dataKey="dataKey"
               tickLine={false}
               tickMargin={10}
               axisLine={false}
               tickFormatter={(value) => value.slice(0, 3)}
             />
-            <YAxis tickLine={false} axisLine={false} width={12} />
+            <YAxis tickLine={false} axisLine={false} width={20} />
             <ChartTooltip content={<ChartTooltipContent />} trigger="click" />
             <ChartLegend content={<ChartLegendContent />} />
             <Bar

--- a/src/components/pages/stats/EmotionBarChart.tsx
+++ b/src/components/pages/stats/EmotionBarChart.tsx
@@ -61,9 +61,16 @@ export function Component() {
               stackId="a"
               fill="var(--color-positive)"
               radius={[0, 0, 4, 4]}
+              barSize={10}
             />
-            <Bar dataKey="negative" stackId="a" fill="var(--color-negative)" />
-            <Bar dataKey="neutral" stackId="a" fill="var(--color-neutral)" radius={[4, 4, 0, 0]} />
+            <Bar dataKey="negative" stackId="a" fill="var(--color-negative)" barSize={10} />
+            <Bar
+              dataKey="neutral"
+              stackId="a"
+              fill="var(--color-neutral)"
+              radius={[4, 4, 0, 0]}
+              barSize={10}
+            />
           </BarChart>
         </ChartContainer>
       </CardContent>

--- a/src/components/pages/stats/EmotionPie.tsx
+++ b/src/components/pages/stats/EmotionPie.tsx
@@ -84,7 +84,7 @@ export function Component() {
       <CardContent className="flex-1">
         <ChartContainer config={chartConfig} className="mx-auto min-h-[400px] w-full">
           <PieChart>
-            <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
+            <ChartTooltip cursor={false} content={<ChartTooltipContent />} trigger="click" />
             <Pie
               data={chartData}
               dataKey="diaryCount"

--- a/src/components/pages/stats/EmotionPie.tsx
+++ b/src/components/pages/stats/EmotionPie.tsx
@@ -1,14 +1,6 @@
-import { TrendingUp } from "lucide-react";
 import { Pie, PieChart } from "recharts";
 
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import {
   ChartConfig,
   ChartContainer,
@@ -17,12 +9,6 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
-
-const EmotionPie = () => {
-  return <Component></Component>;
-};
-
-export default EmotionPie;
 
 const chartData = [
   { emotion: "JOY", diaryCount: 275, fill: "var(--color-JOY)" },
@@ -78,7 +64,7 @@ const chartConfig = {
   },
 } satisfies ChartConfig;
 
-export function Component() {
+const EmotionPie = () => {
   return (
     <Card>
       <CardContent className="flex-1">
@@ -100,4 +86,6 @@ export function Component() {
       </CardContent>
     </Card>
   );
-}
+};
+
+export default EmotionPie;

--- a/src/components/pages/stats/EmotionPie.tsx
+++ b/src/components/pages/stats/EmotionPie.tsx
@@ -1,0 +1,103 @@
+import { TrendingUp } from "lucide-react";
+import { Pie, PieChart } from "recharts";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+
+const EmotionPie = () => {
+  return <Component></Component>;
+};
+
+export default EmotionPie;
+
+const chartData = [
+  { emotion: "JOY", diaryCount: 275, fill: "var(--color-JOY)" },
+  { emotion: "SADNESS", diaryCount: 200, fill: "var(--color-SADNESS)" },
+  { emotion: "ANGER", diaryCount: 187, fill: "var(--color-ANGER)" },
+  { emotion: "FEAR", diaryCount: 173, fill: "var(--color-FEAR)" },
+  { emotion: "DISGUST", diaryCount: 90, fill: "var(--color-DISGUST)" },
+  { emotion: "SHAME", diaryCount: 200, fill: "var(--color-SHAME)" },
+  { emotion: "SURPRISE", diaryCount: 187, fill: "var(--color-SURPRISE)" },
+  { emotion: "CURIOSITY", diaryCount: 173, fill: "var(--color-CURIOSITY)" },
+  { emotion: "NONE", diaryCount: 90, fill: "var(--color-NONE)" },
+];
+
+const chartConfig = {
+  diaryCount: {
+    label: "일기 개수",
+  },
+  JOY: {
+    label: "기쁨",
+    color: "hsl(var(--chart-1))",
+  },
+  SADNESS: {
+    label: "슬픔",
+    color: "hsl(var(--chart-2))",
+  },
+  ANGER: {
+    label: "분노",
+    color: "hsl(var(--chart-3))",
+  },
+  FEAR: {
+    label: "공포",
+    color: "hsl(var(--chart-4))",
+  },
+  DISGUST: {
+    label: "혐오",
+    color: "hsl(var(--chart-5))",
+  },
+  SHAME: {
+    label: "수치",
+    color: "hsl(var(--chart-2))",
+  },
+  SURPRISE: {
+    label: "놀람",
+    color: "hsl(var(--chart-3))",
+  },
+  CURIOSITY: {
+    label: "궁금",
+    color: "hsl(var(--chart-4))",
+  },
+  NONE: {
+    label: "무난",
+    color: "hsl(var(--chart-5))",
+  },
+} satisfies ChartConfig;
+
+export function Component() {
+  return (
+    <Card>
+      <CardContent className="flex-1">
+        <ChartContainer config={chartConfig} className="mx-auto min-h-[400px] w-full">
+          <PieChart>
+            <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
+            <Pie
+              data={chartData}
+              dataKey="diaryCount"
+              nameKey="emotion"
+              innerRadius={70}
+              outerRadius={100}
+            />
+            <ChartLegend
+              content={<ChartLegendContent className="mt-900 grid grid-cols-2" />}
+            ></ChartLegend>
+          </PieChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/pages/stats/EmotionPie.tsx
+++ b/src/components/pages/stats/EmotionPie.tsx
@@ -42,19 +42,19 @@ const chartConfig = {
   },
   JOY: {
     label: "기쁨",
-    color: "hsl(var(--chart-1))",
+    color: "#FFED4C",
   },
   SADNESS: {
     label: "슬픔",
-    color: "hsl(var(--chart-2))",
+    color: "#33A1FF",
   },
   ANGER: {
     label: "분노",
-    color: "hsl(var(--chart-3))",
+    color: "#FF5757",
   },
   FEAR: {
     label: "공포",
-    color: "hsl(var(--chart-4))",
+    color: "#626262",
   },
   DISGUST: {
     label: "혐오",
@@ -62,15 +62,15 @@ const chartConfig = {
   },
   SHAME: {
     label: "수치",
-    color: "hsl(var(--chart-2))",
+    color: "#FF60FC",
   },
   SURPRISE: {
     label: "놀람",
-    color: "hsl(var(--chart-3))",
+    color: "#FF8336",
   },
   CURIOSITY: {
     label: "궁금",
-    color: "hsl(var(--chart-4))",
+    color: "#2DDB44",
   },
   NONE: {
     label: "무난",

--- a/src/components/pages/stats/EmotionPieChart.tsx
+++ b/src/components/pages/stats/EmotionPieChart.tsx
@@ -10,17 +10,9 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart";
 
-const chartData = [
-  { emotion: "JOY", diaryCount: 275, fill: "var(--color-JOY)" },
-  { emotion: "SADNESS", diaryCount: 200, fill: "var(--color-SADNESS)" },
-  { emotion: "ANGER", diaryCount: 187, fill: "var(--color-ANGER)" },
-  { emotion: "FEAR", diaryCount: 173, fill: "var(--color-FEAR)" },
-  { emotion: "DISGUST", diaryCount: 90, fill: "var(--color-DISGUST)" },
-  { emotion: "SHAME", diaryCount: 200, fill: "var(--color-SHAME)" },
-  { emotion: "SURPRISE", diaryCount: 187, fill: "var(--color-SURPRISE)" },
-  { emotion: "CURIOSITY", diaryCount: 173, fill: "var(--color-CURIOSITY)" },
-  { emotion: "NONE", diaryCount: 90, fill: "var(--color-NONE)" },
-];
+interface EmotionPieChartProps {
+  chartData: { emotion: string; diaryCount: number; fill: string }[];
+}
 
 const chartConfig = {
   diaryCount: {
@@ -64,7 +56,7 @@ const chartConfig = {
   },
 } satisfies ChartConfig;
 
-const EmotionPie = () => {
+const EmotionPieChart = ({ chartData }: EmotionPieChartProps) => {
   return (
     <Card>
       <CardContent className="flex-1">
@@ -88,4 +80,4 @@ const EmotionPie = () => {
   );
 };
 
-export default EmotionPie;
+export default EmotionPieChart;

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -6,7 +6,7 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)}
+      className={cn("rounded-lg border bg-card text-card-foreground shadow-default", className)}
       {...props}
     />
   )

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)}
+      {...props}
+    />
+  )
+);
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+  )
+);
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("text-2xl font-semibold leading-none tracking-tight", className)}
+      {...props}
+    />
+  )
+);
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+  )
+);
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-3 py-600", className)} {...props} />
+  )
+);
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+  )
+);
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -1,0 +1,363 @@
+import * as React from "react"
+import * as RechartsPrimitive from "recharts"
+
+import { cn } from "@/lib/utils"
+
+// Format: { THEME_NAME: CSS_SELECTOR }
+const THEMES = { light: "", dark: ".dark" } as const
+
+export type ChartConfig = {
+  [k in string]: {
+    label?: React.ReactNode
+    icon?: React.ComponentType
+  } & (
+    | { color?: string; theme?: never }
+    | { color?: never; theme: Record<keyof typeof THEMES, string> }
+  )
+}
+
+type ChartContextProps = {
+  config: ChartConfig
+}
+
+const ChartContext = React.createContext<ChartContextProps | null>(null)
+
+function useChart() {
+  const context = React.useContext(ChartContext)
+
+  if (!context) {
+    throw new Error("useChart must be used within a <ChartContainer />")
+  }
+
+  return context
+}
+
+const ChartContainer = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div"> & {
+    config: ChartConfig
+    children: React.ComponentProps<
+      typeof RechartsPrimitive.ResponsiveContainer
+    >["children"]
+  }
+>(({ id, className, children, config, ...props }, ref) => {
+  const uniqueId = React.useId()
+  const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <div
+        data-chart={chartId}
+        ref={ref}
+        className={cn(
+          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+          className
+        )}
+        {...props}
+      >
+        <ChartStyle id={chartId} config={config} />
+        <RechartsPrimitive.ResponsiveContainer>
+          {children}
+        </RechartsPrimitive.ResponsiveContainer>
+      </div>
+    </ChartContext.Provider>
+  )
+})
+ChartContainer.displayName = "Chart"
+
+const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+  const colorConfig = Object.entries(config).filter(
+    ([_, config]) => config.theme || config.color
+  )
+
+  if (!colorConfig.length) {
+    return null
+  }
+
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: Object.entries(THEMES)
+          .map(
+            ([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+  .map(([key, itemConfig]) => {
+    const color =
+      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
+      itemConfig.color
+    return color ? `  --color-${key}: ${color};` : null
+  })
+  .join("\n")}
+}
+`
+          )
+          .join("\n"),
+      }}
+    />
+  )
+}
+
+const ChartTooltip = RechartsPrimitive.Tooltip
+
+const ChartTooltipContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
+    React.ComponentProps<"div"> & {
+      hideLabel?: boolean
+      hideIndicator?: boolean
+      indicator?: "line" | "dot" | "dashed"
+      nameKey?: string
+      labelKey?: string
+    }
+>(
+  (
+    {
+      active,
+      payload,
+      className,
+      indicator = "dot",
+      hideLabel = false,
+      hideIndicator = false,
+      label,
+      labelFormatter,
+      labelClassName,
+      formatter,
+      color,
+      nameKey,
+      labelKey,
+    },
+    ref
+  ) => {
+    const { config } = useChart()
+
+    const tooltipLabel = React.useMemo(() => {
+      if (hideLabel || !payload?.length) {
+        return null
+      }
+
+      const [item] = payload
+      const key = `${labelKey || item.dataKey || item.name || "value"}`
+      const itemConfig = getPayloadConfigFromPayload(config, item, key)
+      const value =
+        !labelKey && typeof label === "string"
+          ? config[label as keyof typeof config]?.label || label
+          : itemConfig?.label
+
+      if (labelFormatter) {
+        return (
+          <div className={cn("font-medium", labelClassName)}>
+            {labelFormatter(value, payload)}
+          </div>
+        )
+      }
+
+      if (!value) {
+        return null
+      }
+
+      return <div className={cn("font-medium", labelClassName)}>{value}</div>
+    }, [
+      label,
+      labelFormatter,
+      payload,
+      hideLabel,
+      labelClassName,
+      config,
+      labelKey,
+    ])
+
+    if (!active || !payload?.length) {
+      return null
+    }
+
+    const nestLabel = payload.length === 1 && indicator !== "dot"
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
+          className
+        )}
+      >
+        {!nestLabel ? tooltipLabel : null}
+        <div className="grid gap-1.5">
+          {payload.map((item, index) => {
+            const key = `${nameKey || item.name || item.dataKey || "value"}`
+            const itemConfig = getPayloadConfigFromPayload(config, item, key)
+            const indicatorColor = color || item.payload.fill || item.color
+
+            return (
+              <div
+                key={item.dataKey}
+                className={cn(
+                  "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
+                  indicator === "dot" && "items-center"
+                )}
+              >
+                {formatter && item?.value !== undefined && item.name ? (
+                  formatter(item.value, item.name, item, index, item.payload)
+                ) : (
+                  <>
+                    {itemConfig?.icon ? (
+                      <itemConfig.icon />
+                    ) : (
+                      !hideIndicator && (
+                        <div
+                          className={cn(
+                            "shrink-0 rounded-[2px] border-[--color-border] bg-[--color-bg]",
+                            {
+                              "h-2.5 w-2.5": indicator === "dot",
+                              "w-1": indicator === "line",
+                              "w-0 border-[1.5px] border-dashed bg-transparent":
+                                indicator === "dashed",
+                              "my-0.5": nestLabel && indicator === "dashed",
+                            }
+                          )}
+                          style={
+                            {
+                              "--color-bg": indicatorColor,
+                              "--color-border": indicatorColor,
+                            } as React.CSSProperties
+                          }
+                        />
+                      )
+                    )}
+                    <div
+                      className={cn(
+                        "flex flex-1 justify-between leading-none",
+                        nestLabel ? "items-end" : "items-center"
+                      )}
+                    >
+                      <div className="grid gap-1.5">
+                        {nestLabel ? tooltipLabel : null}
+                        <span className="text-muted-foreground">
+                          {itemConfig?.label || item.name}
+                        </span>
+                      </div>
+                      {item.value && (
+                        <span className="font-mono font-medium tabular-nums text-foreground">
+                          {item.value.toLocaleString()}
+                        </span>
+                      )}
+                    </div>
+                  </>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    )
+  }
+)
+ChartTooltipContent.displayName = "ChartTooltip"
+
+const ChartLegend = RechartsPrimitive.Legend
+
+const ChartLegendContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div"> &
+    Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
+      hideIcon?: boolean
+      nameKey?: string
+    }
+>(
+  (
+    { className, hideIcon = false, payload, verticalAlign = "bottom", nameKey },
+    ref
+  ) => {
+    const { config } = useChart()
+
+    if (!payload?.length) {
+      return null
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "flex items-center justify-center gap-4",
+          verticalAlign === "top" ? "pb-3" : "pt-3",
+          className
+        )}
+      >
+        {payload.map((item) => {
+          const key = `${nameKey || item.dataKey || "value"}`
+          const itemConfig = getPayloadConfigFromPayload(config, item, key)
+
+          return (
+            <div
+              key={item.value}
+              className={cn(
+                "flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground"
+              )}
+            >
+              {itemConfig?.icon && !hideIcon ? (
+                <itemConfig.icon />
+              ) : (
+                <div
+                  className="h-2 w-2 shrink-0 rounded-[2px]"
+                  style={{
+                    backgroundColor: item.color,
+                  }}
+                />
+              )}
+              {itemConfig?.label}
+            </div>
+          )
+        })}
+      </div>
+    )
+  }
+)
+ChartLegendContent.displayName = "ChartLegend"
+
+// Helper to extract item config from a payload.
+function getPayloadConfigFromPayload(
+  config: ChartConfig,
+  payload: unknown,
+  key: string
+) {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined
+  }
+
+  const payloadPayload =
+    "payload" in payload &&
+    typeof payload.payload === "object" &&
+    payload.payload !== null
+      ? payload.payload
+      : undefined
+
+  let configLabelKey: string = key
+
+  if (
+    key in payload &&
+    typeof payload[key as keyof typeof payload] === "string"
+  ) {
+    configLabelKey = payload[key as keyof typeof payload] as string
+  } else if (
+    payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
+  ) {
+    configLabelKey = payloadPayload[
+      key as keyof typeof payloadPayload
+    ] as string
+  }
+
+  return configLabelKey in config
+    ? config[configLabelKey]
+    : config[key as keyof typeof config]
+}
+
+export {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  ChartStyle,
+}

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -1,48 +1,46 @@
-import * as React from "react"
-import * as RechartsPrimitive from "recharts"
+import * as React from "react";
+import * as RechartsPrimitive from "recharts";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 // Format: { THEME_NAME: CSS_SELECTOR }
-const THEMES = { light: "", dark: ".dark" } as const
+const THEMES = { light: "", dark: ".dark" } as const;
 
 export type ChartConfig = {
   [k in string]: {
-    label?: React.ReactNode
-    icon?: React.ComponentType
+    label?: React.ReactNode;
+    icon?: React.ComponentType;
   } & (
     | { color?: string; theme?: never }
     | { color?: never; theme: Record<keyof typeof THEMES, string> }
-  )
-}
+  );
+};
 
 type ChartContextProps = {
-  config: ChartConfig
-}
+  config: ChartConfig;
+};
 
-const ChartContext = React.createContext<ChartContextProps | null>(null)
+const ChartContext = React.createContext<ChartContextProps | null>(null);
 
 function useChart() {
-  const context = React.useContext(ChartContext)
+  const context = React.useContext(ChartContext);
 
   if (!context) {
-    throw new Error("useChart must be used within a <ChartContainer />")
+    throw new Error("useChart must be used within a <ChartContainer />");
   }
 
-  return context
+  return context;
 }
 
 const ChartContainer = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div"> & {
-    config: ChartConfig
-    children: React.ComponentProps<
-      typeof RechartsPrimitive.ResponsiveContainer
-    >["children"]
+    config: ChartConfig;
+    children: React.ComponentProps<typeof RechartsPrimitive.ResponsiveContainer>["children"];
   }
 >(({ id, className, children, config, ...props }, ref) => {
-  const uniqueId = React.useId()
-  const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`
+  const uniqueId = React.useId();
+  const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`;
 
   return (
     <ChartContext.Provider value={{ config }}>
@@ -56,22 +54,18 @@ const ChartContainer = React.forwardRef<
         {...props}
       >
         <ChartStyle id={chartId} config={config} />
-        <RechartsPrimitive.ResponsiveContainer>
-          {children}
-        </RechartsPrimitive.ResponsiveContainer>
+        <RechartsPrimitive.ResponsiveContainer>{children}</RechartsPrimitive.ResponsiveContainer>
       </div>
     </ChartContext.Provider>
-  )
-})
-ChartContainer.displayName = "Chart"
+  );
+});
+ChartContainer.displayName = "Chart";
 
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
-  const colorConfig = Object.entries(config).filter(
-    ([_, config]) => config.theme || config.color
-  )
+  const colorConfig = Object.entries(config).filter(([_, config]) => config.theme || config.color);
 
   if (!colorConfig.length) {
-    return null
+    return null;
   }
 
   return (
@@ -83,10 +77,8 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
 ${prefix} [data-chart=${id}] {
 ${colorConfig
   .map(([key, itemConfig]) => {
-    const color =
-      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
-      itemConfig.color
-    return color ? `  --color-${key}: ${color};` : null
+    const color = itemConfig.theme?.[theme as keyof typeof itemConfig.theme] || itemConfig.color;
+    return color ? `  --color-${key}: ${color};` : null;
   })
   .join("\n")}
 }
@@ -95,20 +87,20 @@ ${colorConfig
           .join("\n"),
       }}
     />
-  )
-}
+  );
+};
 
-const ChartTooltip = RechartsPrimitive.Tooltip
+const ChartTooltip = RechartsPrimitive.Tooltip;
 
 const ChartTooltipContent = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
     React.ComponentProps<"div"> & {
-      hideLabel?: boolean
-      hideIndicator?: boolean
-      indicator?: "line" | "dot" | "dashed"
-      nameKey?: string
-      labelKey?: string
+      hideLabel?: boolean;
+      hideIndicator?: boolean;
+      indicator?: "line" | "dot" | "dashed";
+      nameKey?: string;
+      labelKey?: string;
     }
 >(
   (
@@ -129,49 +121,39 @@ const ChartTooltipContent = React.forwardRef<
     },
     ref
   ) => {
-    const { config } = useChart()
+    const { config } = useChart();
 
     const tooltipLabel = React.useMemo(() => {
       if (hideLabel || !payload?.length) {
-        return null
+        return null;
       }
 
-      const [item] = payload
-      const key = `${labelKey || item.dataKey || item.name || "value"}`
-      const itemConfig = getPayloadConfigFromPayload(config, item, key)
+      const [item] = payload;
+      const key = `${labelKey || item.dataKey || item.name || "value"}`;
+      const itemConfig = getPayloadConfigFromPayload(config, item, key);
       const value =
         !labelKey && typeof label === "string"
           ? config[label as keyof typeof config]?.label || label
-          : itemConfig?.label
+          : itemConfig?.label;
 
       if (labelFormatter) {
         return (
-          <div className={cn("font-medium", labelClassName)}>
-            {labelFormatter(value, payload)}
-          </div>
-        )
+          <div className={cn("font-medium", labelClassName)}>{labelFormatter(value, payload)}</div>
+        );
       }
 
       if (!value) {
-        return null
+        return null;
       }
 
-      return <div className={cn("font-medium", labelClassName)}>{value}</div>
-    }, [
-      label,
-      labelFormatter,
-      payload,
-      hideLabel,
-      labelClassName,
-      config,
-      labelKey,
-    ])
+      return <div className={cn("font-medium", labelClassName)}>{value}</div>;
+    }, [label, labelFormatter, payload, hideLabel, labelClassName, config, labelKey]);
 
     if (!active || !payload?.length) {
-      return null
+      return null;
     }
 
-    const nestLabel = payload.length === 1 && indicator !== "dot"
+    const nestLabel = payload.length === 1 && indicator !== "dot";
 
     return (
       <div
@@ -184,9 +166,9 @@ const ChartTooltipContent = React.forwardRef<
         {!nestLabel ? tooltipLabel : null}
         <div className="grid gap-1.5">
           {payload.map((item, index) => {
-            const key = `${nameKey || item.name || item.dataKey || "value"}`
-            const itemConfig = getPayloadConfigFromPayload(config, item, key)
-            const indicatorColor = color || item.payload.fill || item.color
+            const key = `${nameKey || item.name || item.dataKey || "value"}`;
+            const itemConfig = getPayloadConfigFromPayload(config, item, key);
+            const indicatorColor = color || item.payload.fill || item.color;
 
             return (
               <div
@@ -245,112 +227,96 @@ const ChartTooltipContent = React.forwardRef<
                   </>
                 )}
               </div>
-            )
+            );
           })}
         </div>
       </div>
-    )
+    );
   }
-)
-ChartTooltipContent.displayName = "ChartTooltip"
+);
+ChartTooltipContent.displayName = "ChartTooltip";
 
-const ChartLegend = RechartsPrimitive.Legend
+const ChartLegend = RechartsPrimitive.Legend;
 
 const ChartLegendContent = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div"> &
     Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
-      hideIcon?: boolean
-      nameKey?: string
+      hideIcon?: boolean;
+      nameKey?: string;
     }
->(
-  (
-    { className, hideIcon = false, payload, verticalAlign = "bottom", nameKey },
-    ref
-  ) => {
-    const { config } = useChart()
+>(({ className, hideIcon = false, payload, verticalAlign = "bottom", nameKey }, ref) => {
+  const { config } = useChart();
 
-    if (!payload?.length) {
-      return null
-    }
-
-    return (
-      <div
-        ref={ref}
-        className={cn(
-          "flex items-center justify-center gap-4",
-          verticalAlign === "top" ? "pb-3" : "pt-3",
-          className
-        )}
-      >
-        {payload.map((item) => {
-          const key = `${nameKey || item.dataKey || "value"}`
-          const itemConfig = getPayloadConfigFromPayload(config, item, key)
-
-          return (
-            <div
-              key={item.value}
-              className={cn(
-                "flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground"
-              )}
-            >
-              {itemConfig?.icon && !hideIcon ? (
-                <itemConfig.icon />
-              ) : (
-                <div
-                  className="h-2 w-2 shrink-0 rounded-[2px]"
-                  style={{
-                    backgroundColor: item.color,
-                  }}
-                />
-              )}
-              {itemConfig?.label}
-            </div>
-          )
-        })}
-      </div>
-    )
+  if (!payload?.length) {
+    return null;
   }
-)
-ChartLegendContent.displayName = "ChartLegend"
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "flex items-center justify-center gap-4",
+        verticalAlign === "top" ? "pb-3" : "pt-3",
+        className
+      )}
+    >
+      {payload.map((item) => {
+        const key = `${nameKey || item.dataKey || "value"}`;
+        const itemConfig = getPayloadConfigFromPayload(config, item, key);
+
+        return (
+          <div
+            key={item.value}
+            className={cn(
+              "flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground"
+            )}
+          >
+            {itemConfig?.icon && !hideIcon ? (
+              <itemConfig.icon />
+            ) : (
+              <div
+                className="h-2 w-2 shrink-0 rounded-full"
+                style={{
+                  backgroundColor: item.color,
+                }}
+              />
+            )}
+            <span className="flex gap-200 text-detail-1 text-gray-600">
+              {itemConfig?.label} <span className="text-primary-normal">{item.payload?.value}</span>
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+});
+ChartLegendContent.displayName = "ChartLegend";
 
 // Helper to extract item config from a payload.
-function getPayloadConfigFromPayload(
-  config: ChartConfig,
-  payload: unknown,
-  key: string
-) {
+function getPayloadConfigFromPayload(config: ChartConfig, payload: unknown, key: string) {
   if (typeof payload !== "object" || payload === null) {
-    return undefined
+    return undefined;
   }
 
   const payloadPayload =
-    "payload" in payload &&
-    typeof payload.payload === "object" &&
-    payload.payload !== null
+    "payload" in payload && typeof payload.payload === "object" && payload.payload !== null
       ? payload.payload
-      : undefined
+      : undefined;
 
-  let configLabelKey: string = key
+  let configLabelKey: string = key;
 
-  if (
-    key in payload &&
-    typeof payload[key as keyof typeof payload] === "string"
-  ) {
-    configLabelKey = payload[key as keyof typeof payload] as string
+  if (key in payload && typeof payload[key as keyof typeof payload] === "string") {
+    configLabelKey = payload[key as keyof typeof payload] as string;
   } else if (
     payloadPayload &&
     key in payloadPayload &&
     typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
   ) {
-    configLabelKey = payloadPayload[
-      key as keyof typeof payloadPayload
-    ] as string
+    configLabelKey = payloadPayload[key as keyof typeof payloadPayload] as string;
   }
 
-  return configLabelKey in config
-    ? config[configLabelKey]
-    : config[key as keyof typeof config]
+  return configLabelKey in config ? config[configLabelKey] : config[key as keyof typeof config];
 }
 
 export {
@@ -360,4 +326,4 @@ export {
   ChartLegend,
   ChartLegendContent,
   ChartStyle,
-}
+};

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+
+import { cn } from "@/lib/utils";
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-md bg-primary-light-2 p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-50 px-3 py-1.5 text-sm font-medium text-primary-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-primary-normal data-[state=active]:text-white data-[state=active]:shadow-sm",
+      className
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import Appbar from "../components/common/Appbar";
 import Divider from "../components/common/Divider";
 import Toggle from "../components/common/Toggle";
+import { useNavigate } from "react-router-dom";
 
 /**
  * 마이페이지 화면
@@ -9,6 +10,7 @@ import Toggle from "../components/common/Toggle";
  */
 const Mypage = () => {
   const [dark, setDark] = useState(false);
+  const navigate = useNavigate();
   return (
     <div className="flex flex-grow flex-col overflow-scroll">
       <Appbar text="마이페이지"></Appbar>
@@ -23,7 +25,9 @@ const Mypage = () => {
           />
         </div>
         <Divider />
-        <button className="w-full text-start">통계</button>
+        <button className="w-full text-start" onClick={() => navigate("stats")}>
+          통계
+        </button>
         <Divider />
         <button className="w-full text-start text-status-negative">회원탈퇴</button>
         <Divider />

--- a/src/pages/stats/EmotionStats.tsx
+++ b/src/pages/stats/EmotionStats.tsx
@@ -1,3 +1,4 @@
+import EmotionBarChart from "@/components/pages/stats/EmotionBarChart";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 const EmotionStats = () => {
@@ -16,7 +17,7 @@ const EmotionStats = () => {
           <div>
             <div>월 선택</div>
             <div>
-              <div>막대 그래프</div>
+              <EmotionBarChart></EmotionBarChart>
             </div>
             <div>원 그래프</div>
           </div>

--- a/src/pages/stats/EmotionStats.tsx
+++ b/src/pages/stats/EmotionStats.tsx
@@ -4,7 +4,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 const EmotionStats = () => {
   return (
-    <div className="flex w-full flex-col items-center justify-center bg-primary-light-1 px-800 py-500">
+    <div className="flex w-full flex-col items-center justify-center bg-primary-light-1 px-800 pb-1000 pt-500">
       <Tabs defaultValue="week" className="w-full text-center font-Binggrae">
         <TabsList className="w-full">
           <TabsTrigger value="week" className="w-full">

--- a/src/pages/stats/EmotionStats.tsx
+++ b/src/pages/stats/EmotionStats.tsx
@@ -1,6 +1,48 @@
 import EmotionBarChart from "@/components/pages/stats/EmotionBarChart";
-import EmotionPie from "@/components/pages/stats/EmotionPie";
+import EmotionPieChart from "@/components/pages/stats/EmotionPieChart";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+const WeeklyEmotionBarData = [
+  { dataKey: "5주전", positive: 1, neutral: 3, negative: 2 },
+  { dataKey: "4주전", positive: 1, neutral: 1, negative: 4 },
+  { dataKey: "3주전", positive: 2, neutral: 2, negative: 3 },
+  { dataKey: "2주전", positive: 1, neutral: 1, negative: 0 },
+  { dataKey: "저번주", positive: 2, neutral: 4, negative: 1 },
+  { dataKey: "이번주", positive: 3, neutral: 1, negative: 2 },
+];
+
+const MonthlyEmotionBarData = [
+  { dataKey: "5달전", positive: 8, neutral: 10, negative: 11 },
+  { dataKey: "4달전", positive: 12, neutral: 7, negative: 14 },
+  { dataKey: "3달전", positive: 8, neutral: 20, negative: 1 },
+  { dataKey: "2달전", positive: 8, neutral: 10, negative: 12 },
+  { dataKey: "저번달", positive: 18, neutral: 2, negative: 8 },
+  { dataKey: "이번달", positive: 8, neutral: 10, negative: 14 },
+];
+
+const WeeklyEmotionPieData = [
+  { emotion: "JOY", diaryCount: 2, fill: "var(--color-JOY)" },
+  { emotion: "SADNESS", diaryCount: 2, fill: "var(--color-SADNESS)" },
+  { emotion: "ANGER", diaryCount: 1, fill: "var(--color-ANGER)" },
+  { emotion: "FEAR", diaryCount: 1, fill: "var(--color-FEAR)" },
+  { emotion: "DISGUST", diaryCount: 1, fill: "var(--color-DISGUST)" },
+  { emotion: "SHAME", diaryCount: 2, fill: "var(--color-SHAME)" },
+  { emotion: "SURPRISE", diaryCount: 1, fill: "var(--color-SURPRISE)" },
+  { emotion: "CURIOSITY", diaryCount: 1, fill: "var(--color-CURIOSITY)" },
+  { emotion: "NONE", diaryCount: 1, fill: "var(--color-NONE)" },
+];
+
+const MonthlyEmotionPieData = [
+  { emotion: "JOY", diaryCount: 27, fill: "var(--color-JOY)" },
+  { emotion: "SADNESS", diaryCount: 20, fill: "var(--color-SADNESS)" },
+  { emotion: "ANGER", diaryCount: 18, fill: "var(--color-ANGER)" },
+  { emotion: "FEAR", diaryCount: 17, fill: "var(--color-FEAR)" },
+  { emotion: "DISGUST", diaryCount: 9, fill: "var(--color-DISGUST)" },
+  { emotion: "SHAME", diaryCount: 20, fill: "var(--color-SHAME)" },
+  { emotion: "SURPRISE", diaryCount: 18, fill: "var(--color-SURPRISE)" },
+  { emotion: "CURIOSITY", diaryCount: 17, fill: "var(--color-CURIOSITY)" },
+  { emotion: "NONE", diaryCount: 9, fill: "var(--color-NONE)" },
+];
 
 const EmotionStats = () => {
   return (
@@ -17,19 +59,19 @@ const EmotionStats = () => {
         <TabsContent value="week" className="flex flex-col gap-800">
           <div>주 선택</div>
           <div>
-            <EmotionBarChart></EmotionBarChart>
+            <EmotionBarChart chartData={WeeklyEmotionBarData}></EmotionBarChart>
           </div>
           <div>
-            <EmotionPie></EmotionPie>
+            <EmotionPieChart chartData={WeeklyEmotionPieData}></EmotionPieChart>
           </div>
         </TabsContent>
         <TabsContent value="month" className="flex flex-col gap-800">
           <div>월 선택</div>
           <div>
-            <EmotionBarChart></EmotionBarChart>
+            <EmotionBarChart chartData={MonthlyEmotionBarData}></EmotionBarChart>
           </div>
           <div>
-            <EmotionPie></EmotionPie>
+            <EmotionPieChart chartData={MonthlyEmotionPieData}></EmotionPieChart>
           </div>
         </TabsContent>
       </Tabs>

--- a/src/pages/stats/EmotionStats.tsx
+++ b/src/pages/stats/EmotionStats.tsx
@@ -12,8 +12,18 @@ const EmotionStats = () => {
             1달
           </TabsTrigger>
         </TabsList>
-        <TabsContent value="week">Make changes to your account here.</TabsContent>
-        <TabsContent value="month">Change your password here.</TabsContent>
+        <TabsContent value="week">
+          <div>
+            <div>월 선택</div>
+            <div>
+              <div>막대 그래프</div>
+            </div>
+            <div>원 그래프</div>
+          </div>
+        </TabsContent>
+        <TabsContent value="month">
+          <div></div>
+        </TabsContent>
       </Tabs>
     </div>
   );

--- a/src/pages/stats/EmotionStats.tsx
+++ b/src/pages/stats/EmotionStats.tsx
@@ -1,11 +1,12 @@
 import EmotionBarChart from "@/components/pages/stats/EmotionBarChart";
+import EmotionPie from "@/components/pages/stats/EmotionPie";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 const EmotionStats = () => {
   return (
     <div className="flex w-full flex-col items-center justify-center bg-primary-light-1 px-800 py-500">
       <Tabs defaultValue="week" className="w-full text-center font-Binggrae">
-        <TabsList className="w-80">
+        <TabsList className="w-full">
           <TabsTrigger value="week" className="w-full">
             1주
           </TabsTrigger>
@@ -13,13 +14,13 @@ const EmotionStats = () => {
             1달
           </TabsTrigger>
         </TabsList>
-        <TabsContent value="week">
+        <TabsContent value="week" className="flex flex-col gap-800">
+          <div>월 선택</div>
           <div>
-            <div>월 선택</div>
-            <div>
-              <EmotionBarChart></EmotionBarChart>
-            </div>
-            <div>원 그래프</div>
+            <EmotionBarChart></EmotionBarChart>
+          </div>
+          <div>
+            <EmotionPie></EmotionPie>
           </div>
         </TabsContent>
         <TabsContent value="month">

--- a/src/pages/stats/EmotionStats.tsx
+++ b/src/pages/stats/EmotionStats.tsx
@@ -1,0 +1,22 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+const EmotionStats = () => {
+  return (
+    <div className="flex w-full flex-col items-center justify-center bg-primary-light-1 px-800 py-500">
+      <Tabs defaultValue="week" className="w-full text-center font-Binggrae">
+        <TabsList className="w-80">
+          <TabsTrigger value="week" className="w-full">
+            1주
+          </TabsTrigger>
+          <TabsTrigger value="month" className="w-full">
+            1달
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="week">Make changes to your account here.</TabsContent>
+        <TabsContent value="month">Change your password here.</TabsContent>
+      </Tabs>
+    </div>
+  );
+};
+
+export default EmotionStats;

--- a/src/pages/stats/EmotionStats.tsx
+++ b/src/pages/stats/EmotionStats.tsx
@@ -15,7 +15,7 @@ const EmotionStats = () => {
           </TabsTrigger>
         </TabsList>
         <TabsContent value="week" className="flex flex-col gap-800">
-          <div>월 선택</div>
+          <div>주 선택</div>
           <div>
             <EmotionBarChart></EmotionBarChart>
           </div>
@@ -23,8 +23,14 @@ const EmotionStats = () => {
             <EmotionPie></EmotionPie>
           </div>
         </TabsContent>
-        <TabsContent value="month">
-          <div></div>
+        <TabsContent value="month" className="flex flex-col gap-800">
+          <div>월 선택</div>
+          <div>
+            <EmotionBarChart></EmotionBarChart>
+          </div>
+          <div>
+            <EmotionPie></EmotionPie>
+          </div>
         </TabsContent>
       </Tabs>
     </div>

--- a/src/pages/stats/KeywordStats.tsx
+++ b/src/pages/stats/KeywordStats.tsx
@@ -1,0 +1,22 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+const KeywordStats = () => {
+  return (
+    <div className="flex w-full flex-col items-center justify-center bg-primary-light-1 px-800 py-500">
+      <Tabs defaultValue="week" className="w-full text-center font-Binggrae">
+        <TabsList className="w-80">
+          <TabsTrigger value="week" className="w-full">
+            1주
+          </TabsTrigger>
+          <TabsTrigger value="month" className="w-full">
+            1달
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="week">Make changes to your account here.</TabsContent>
+        <TabsContent value="month">Change your password here.</TabsContent>
+      </Tabs>
+    </div>
+  );
+};
+
+export default KeywordStats;

--- a/src/pages/stats/Layout/StatsLayout.tsx
+++ b/src/pages/stats/Layout/StatsLayout.tsx
@@ -1,0 +1,53 @@
+import Appbar from "@/components/common/Appbar";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import EmotionStats from "../EmotionStats";
+import KeywordStats from "../KeywordStats";
+
+const buttonPositions = {
+  Emotion: "left-0",
+  Keyword: "left-1/2",
+};
+
+const StatsLayout = () => {
+  const navigate = useNavigate();
+  const [selected, setSelected] = useState("Emotion");
+  const handleChangeSelected = (selected: string) => {
+    setSelected(selected);
+    navigate(`?order=${selected}`);
+  };
+
+  return (
+    <div className="flex-grow overflow-scroll">
+      <Appbar text="통계"></Appbar>
+      <div className="sticky top-0 z-10 flex w-full justify-around gap-500 bg-white font-BinggraeBold text-body-2">
+        <button
+          className="flex w-full items-center justify-center py-400"
+          onClick={() => handleChangeSelected("Emotion")}
+        >
+          <div className={selected === "Emotion" ? "text-primary-normal" : "text-gray-400"}>
+            감정
+          </div>
+        </button>
+        <button
+          className="flex w-full items-center justify-center py-400"
+          onClick={() => handleChangeSelected("Keyword")}
+        >
+          <div className={selected === "Keyword" ? "text-primary-normal" : "text-gray-400"}>
+            키워드
+          </div>
+        </button>
+        <div
+          className={`absolute bottom-0 flex w-1/2 justify-center transition-all duration-300 ${buttonPositions[selected as "Emotion" | "Keyword"]}`}
+        >
+          <div className="h-[2px] w-[7.5rem] bg-primary-normal" />
+        </div>
+        <div className="absolute bottom-0 -z-10 h-[1px] w-full bg-gray-100" />
+      </div>
+
+      {selected === "Emotion" ? <EmotionStats></EmotionStats> : <KeywordStats></KeywordStats>}
+    </div>
+  );
+};
+
+export default StatsLayout;

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -10,6 +10,7 @@ import AlbumFallback from "../components/pages/album/fallback/AlbumFallback";
 import DiaryFallback from "../pages/diary/Fallback/DiaryFallback";
 import DiaryModifyFlowLayout from "@/pages/write/Layout/DiaryModifyFlowLayout";
 import Modify from "@/pages/write/Modify";
+import StatsLayout from "@/pages/stats/Layout/StatsLayout";
 
 const HomePage = lazy(() => import("../pages/Home"));
 const ExplorePage = lazy(() => import("../pages/Explore"));
@@ -67,6 +68,14 @@ const routes: RouteObject[] = [
         element: (
           <Suspense fallback={<PageFallback />}>
             <Mypage />
+          </Suspense>
+        ),
+      },
+      {
+        path: `${RoutePaths.mypage}/stats`,
+        element: (
+          <Suspense fallback={<PageFallback />}>
+            <StatsLayout />
           </Suspense>
         ),
       },

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -8,22 +8,22 @@ import DiaryWriteFlowLayout from "../pages/write/Layout/DiaryWriteFlowLayout";
 import { ErrorBoundary } from "react-error-boundary";
 import AlbumFallback from "../components/pages/album/fallback/AlbumFallback";
 import DiaryFallback from "../pages/diary/Fallback/DiaryFallback";
-import DiaryModifyFlowLayout from "@/pages/write/Layout/DiaryModifyFlowLayout";
-import Modify from "@/pages/write/Modify";
-import StatsLayout from "@/pages/stats/Layout/StatsLayout";
 
 const HomePage = lazy(() => import("../pages/Home"));
 const ExplorePage = lazy(() => import("../pages/Explore"));
 const AlbumPage = lazy(() => import("../pages/Album"));
 const Mypage = lazy(() => import("../pages/Mypage"));
 const Login = lazy(() => import("../pages/Login"));
+const Stats = lazy(() => import("@/pages/stats/Layout/StatsLayout"));
 
 const DiaryLayout = lazy(() => import("../pages/diary/Layout/DiaryLayout"));
+const DiaryModifyFlowLayout = lazy(() => import("@/pages/write/Layout/DiaryModifyFlowLayout"));
 
 const Draw = lazy(() => import("../pages/write/Draw"));
 const Review = lazy(() => import("../pages/write/Review"));
 const Style = lazy(() => import("../pages/write/Style"));
 const Write = lazy(() => import("../pages/write/Write"));
+const Modify = lazy(() => import("@/pages/write/Modify"));
 
 const ErrorPage = lazy(() => import("../pages/error/Error"));
 const NotFoundErrorPage = lazy(() => import("../pages/error/NotFoundError"));
@@ -75,7 +75,7 @@ const routes: RouteObject[] = [
         path: `${RoutePaths.mypage}/stats`,
         element: (
           <Suspense fallback={<PageFallback />}>
-            <StatsLayout />
+            <Stats />
           </Suspense>
         ),
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -167,6 +167,13 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.0.tgz#8600c2f595f277c60815256418b85356a65173c1"
+  integrity sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.25.0":
   version "7.25.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.25.0.tgz#e733dc3134b4fede528c15bc95e89cb98c52592a"
@@ -1366,6 +1373,57 @@
   dependencies:
     "@types/node" "*"
 
+"@types/d3-array@^3.0.3":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-array/-/d3-array-3.2.1.tgz#1f6658e3d2006c4fceac53fde464166859f8b8c5"
+  integrity sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==
+
+"@types/d3-color@*":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-3.1.3.tgz#368c961a18de721da8200e80bf3943fb53136af2"
+  integrity sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==
+
+"@types/d3-ease@^3.0.0":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-ease/-/d3-ease-3.0.2.tgz#e28db1bfbfa617076f7770dd1d9a48eaa3b6c51b"
+  integrity sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==
+
+"@types/d3-interpolate@^3.0.1":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz#412b90e84870285f2ff8a846c6eb60344f12a41c"
+  integrity sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==
+  dependencies:
+    "@types/d3-color" "*"
+
+"@types/d3-path@*":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-3.1.0.tgz#2b907adce762a78e98828f0b438eaca339ae410a"
+  integrity sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ==
+
+"@types/d3-scale@^4.0.2":
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-4.0.8.tgz#d409b5f9dcf63074464bf8ddfb8ee5a1f95945bb"
+  integrity sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==
+  dependencies:
+    "@types/d3-time" "*"
+
+"@types/d3-shape@^3.1.0":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-3.1.6.tgz#65d40d5a548f0a023821773e39012805e6e31a72"
+  integrity sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==
+  dependencies:
+    "@types/d3-path" "*"
+
+"@types/d3-time@*", "@types/d3-time@^3.0.0":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.3.tgz#3c186bbd9d12b9d84253b6be6487ca56b54f88be"
+  integrity sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw==
+
+"@types/d3-timer@^3.0.0":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-timer/-/d3-timer-3.0.2.tgz#70bbda77dc23aa727413e22e214afa3f0e852f70"
+  integrity sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==
+
 "@types/doctrine@^0.0.9":
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/@types/doctrine/-/doctrine-0.0.9.tgz#d86a5f452a15e3e3113b99e39616a9baa0f9863f"
@@ -2226,7 +2284,7 @@ clsx@2.0.0:
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.0.0.tgz#12658f3fd98fafe62075595a5c30e43d18f3d00b"
   integrity sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==
 
-clsx@^2.1.1:
+clsx@^2.0.0, clsx@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
   integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
@@ -2338,6 +2396,77 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
+"d3-array@2 - 3", "d3-array@2.10.0 - 3", d3-array@^3.1.6:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.4.tgz#15fec33b237f97ac5d7c986dc77da273a8ed0bb5"
+  integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
+  dependencies:
+    internmap "1 - 2"
+
+"d3-color@1 - 3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
+
+d3-ease@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-3.0.1.tgz#9658ac38a2140d59d346160f1f6c30fda0bd12f4"
+  integrity sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==
+
+"d3-format@1 - 3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.0.tgz#9260e23a28ea5cb109e93b21a06e24e2ebd55641"
+  integrity sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==
+
+"d3-interpolate@1.2.0 - 3", d3-interpolate@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
+  integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
+  dependencies:
+    d3-color "1 - 3"
+
+d3-path@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-3.1.0.tgz#22df939032fb5a71ae8b1800d61ddb7851c42526"
+  integrity sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==
+
+d3-scale@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
+  integrity sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
+  dependencies:
+    d3-array "2.10.0 - 3"
+    d3-format "1 - 3"
+    d3-interpolate "1.2.0 - 3"
+    d3-time "2.1.1 - 3"
+    d3-time-format "2 - 4"
+
+d3-shape@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-3.2.0.tgz#a1a839cbd9ba45f28674c69d7f855bcf91dfc6a5"
+  integrity sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==
+  dependencies:
+    d3-path "^3.1.0"
+
+"d3-time-format@2 - 4":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-4.1.0.tgz#7ab5257a5041d11ecb4fe70a5c7d16a195bb408a"
+  integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
+  dependencies:
+    d3-time "1 - 3"
+
+"d3-time@1 - 3", "d3-time@2.1.1 - 3", d3-time@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-3.1.0.tgz#9310db56e992e3c0175e1ef385e545e48a9bb5c7"
+  integrity sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==
+  dependencies:
+    d3-array "2 - 3"
+
+d3-timer@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
+  integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
+
 data-view-buffer@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/data-view-buffer/-/data-view-buffer-1.0.1.tgz#8ea6326efec17a2e42620696e671d7d5a8bc66b2"
@@ -2385,6 +2514,11 @@ debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5:
   integrity sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==
   dependencies:
     ms "^2.1.3"
+
+decimal.js-light@^2.4.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/decimal.js-light/-/decimal.js-light-2.5.1.tgz#134fd32508f19e208f4fb2f8dac0d2626a867934"
+  integrity sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==
 
 deep-eql@^5.0.1:
   version "5.0.2"
@@ -2484,6 +2618,14 @@ dom-accessibility-api@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz#993e925cc1d73f2c662e7d75dd5a5445259a8fd8"
   integrity sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==
+
+dom-helpers@^5.0.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dot-case@^3.0.4:
   version "3.0.4"
@@ -3003,6 +3145,11 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
+eventemitter3@^4.0.1:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
+  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+
 express@^4.19.2:
   version "4.21.0"
   resolved "https://registry.yarnpkg.com/express/-/express-4.21.0.tgz#d57cb706d49623d4ac27833f1cbc466b668eb915"
@@ -3049,6 +3196,11 @@ fast-diff@^1.1.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.3.0.tgz#ece407fa550a64d638536cd727e129c61616e0f0"
   integrity sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==
+
+fast-equals@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/fast-equals/-/fast-equals-5.0.1.tgz#a4eefe3c5d1c0d021aeed0bc10ba5e0c12ee405d"
+  integrity sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==
 
 fast-glob@^3.2.9, fast-glob@^3.3.0, fast-glob@^3.3.2:
   version "3.3.2"
@@ -3509,6 +3661,11 @@ internal-slot@^1.0.7:
     es-errors "^1.3.0"
     hasown "^2.0.0"
     side-channel "^1.0.4"
+
+"internmap@1 - 2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
+  integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
 
 invariant@^2.2.4:
   version "2.2.4"
@@ -4458,7 +4615,7 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
 
-prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -4584,6 +4741,11 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+react-is@^18.3.1:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
 react-refresh@^0.14.2:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.2.tgz#3833da01ce32da470f1f936b9d477da5c7028bf9"
@@ -4623,6 +4785,15 @@ react-router@6.26.2:
   dependencies:
     "@remix-run/router" "1.19.2"
 
+react-smooth@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/react-smooth/-/react-smooth-4.0.1.tgz#6200d8699bfe051ae40ba187988323b1449eab1a"
+  integrity sha512-OE4hm7XqR0jNOq3Qmk9mFLyd6p2+j6bvbPJ7qlB7+oo0eNcL2l7WQzG6MBnT3EXY6xzkLMUBec3AfewJdA0J8w==
+  dependencies:
+    fast-equals "^5.0.1"
+    prop-types "^15.8.1"
+    react-transition-group "^4.4.5"
+
 react-style-singleton@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.1.tgz#f99e420492b2d8f34d38308ff660b60d0b1205b4"
@@ -4631,6 +4802,16 @@ react-style-singleton@^2.2.1:
     get-nonce "^1.0.0"
     invariant "^2.2.4"
     tslib "^2.0.0"
+
+react-transition-group@^4.4.5:
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
+  integrity sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 "react@^16.8.0 || ^17.0.0 || ^18.0.0", react@^18.3.1:
   version "18.3.1"
@@ -4663,6 +4844,27 @@ recast@^0.23.5:
     source-map "~0.6.1"
     tiny-invariant "^1.3.3"
     tslib "^2.0.1"
+
+recharts-scale@^0.4.4:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/recharts-scale/-/recharts-scale-0.4.5.tgz#0969271f14e732e642fcc5bd4ab270d6e87dd1d9"
+  integrity sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==
+  dependencies:
+    decimal.js-light "^2.4.1"
+
+recharts@^2.13.3:
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/recharts/-/recharts-2.13.3.tgz#a5ce61e493dff921a14a14a8f42a9f2d2bbefd5a"
+  integrity sha512-YDZ9dOfK9t3ycwxgKbrnDlRC4BHdjlY73fet3a0C1+qGMjXVZe6+VXmpOIIhzkje5MMEL8AN4hLIe4AMskBzlA==
+  dependencies:
+    clsx "^2.0.0"
+    eventemitter3 "^4.0.1"
+    lodash "^4.17.21"
+    react-is "^18.3.1"
+    react-smooth "^4.0.0"
+    recharts-scale "^0.4.4"
+    tiny-invariant "^1.3.1"
+    victory-vendor "^36.6.8"
 
 redent@^3.0.0:
   version "3.0.0"
@@ -5502,6 +5704,26 @@ vaul@^1.1.1:
   integrity sha512-+ejzF6ffQKPcfgS7uOrGn017g39F8SO4yLPXbBhpC7a0H+oPqPna8f1BUfXaz8eU4+pxbQcmjxW+jWBSbxjaFg==
   dependencies:
     "@radix-ui/react-dialog" "^1.1.1"
+
+victory-vendor@^36.6.8:
+  version "36.9.2"
+  resolved "https://registry.yarnpkg.com/victory-vendor/-/victory-vendor-36.9.2.tgz#668b02a448fa4ea0f788dbf4228b7e64669ff801"
+  integrity sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==
+  dependencies:
+    "@types/d3-array" "^3.0.3"
+    "@types/d3-ease" "^3.0.0"
+    "@types/d3-interpolate" "^3.0.1"
+    "@types/d3-scale" "^4.0.2"
+    "@types/d3-shape" "^3.1.0"
+    "@types/d3-time" "^3.0.0"
+    "@types/d3-timer" "^3.0.0"
+    d3-array "^3.1.6"
+    d3-ease "^3.0.1"
+    d3-interpolate "^3.0.1"
+    d3-scale "^4.0.2"
+    d3-shape "^3.1.0"
+    d3-time "^3.0.0"
+    d3-timer "^3.0.1"
 
 vite-plugin-svgr@^4.2.0:
   version "4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -614,10 +614,25 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.0.tgz#42ef83b3b56dccad5d703ae8c42919a68798bbe2"
   integrity sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==
 
+"@radix-ui/react-collection@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.1.0.tgz#f18af78e46454a2360d103c2251773028b7724ed"
+  integrity sha512-GZsZslMJEyo1VKm5L1ZJY8tGDxZNPAoUeQUIbKeJfoi7Q4kmig5AsgLMYYuyYbfjd8fBmFORAIwYAkXMnXZgZw==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.0"
+    "@radix-ui/react-context" "1.1.0"
+    "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-slot" "1.1.0"
+
 "@radix-ui/react-compose-refs@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz#656432461fc8283d7b591dcf0d79152fae9ecc74"
   integrity sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==
+
+"@radix-ui/react-context@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.0.tgz#6df8d983546cfd1999c8512f3a8ad85a6e7fcee8"
+  integrity sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==
 
 "@radix-ui/react-context@1.1.1":
   version "1.1.1"
@@ -643,6 +658,11 @@
     "@radix-ui/react-use-controllable-state" "1.1.0"
     aria-hidden "^1.1.1"
     react-remove-scroll "2.6.0"
+
+"@radix-ui/react-direction@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-direction/-/react-direction-1.1.0.tgz#a7d39855f4d077adc2a1922f9c353c5977a09cdc"
+  integrity sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==
 
 "@radix-ui/react-dismissable-layer@1.1.1":
   version "1.1.1"
@@ -699,12 +719,41 @@
   dependencies:
     "@radix-ui/react-slot" "1.1.0"
 
+"@radix-ui/react-roving-focus@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.0.tgz#b30c59daf7e714c748805bfe11c76f96caaac35e"
+  integrity sha512-EA6AMGeq9AEeQDeSH0aZgG198qkfHSbvWTf1HvoDmOB5bBG/qTxjYMWUKMnYiV6J/iP/J8MEFSuB2zRU2n7ODA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.0"
+    "@radix-ui/react-collection" "1.1.0"
+    "@radix-ui/react-compose-refs" "1.1.0"
+    "@radix-ui/react-context" "1.1.0"
+    "@radix-ui/react-direction" "1.1.0"
+    "@radix-ui/react-id" "1.1.0"
+    "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
+
 "@radix-ui/react-slot@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.1.0.tgz#7c5e48c36ef5496d97b08f1357bb26ed7c714b84"
   integrity sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.0"
+
+"@radix-ui/react-tabs@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tabs/-/react-tabs-1.1.1.tgz#698bd97923f6bcd629738198a73beebcc4c88b30"
+  integrity sha512-3GBUDmP2DvzmtYLMsHmpA1GtR46ZDZ+OreXM/N+kkQJOPIgytFWWTfDQmBQKBvaFS0Vno0FktdbVzN28KGrMdw==
+  dependencies:
+    "@radix-ui/primitive" "1.1.0"
+    "@radix-ui/react-context" "1.1.1"
+    "@radix-ui/react-direction" "1.1.0"
+    "@radix-ui/react-id" "1.1.0"
+    "@radix-ui/react-presence" "1.1.1"
+    "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-roving-focus" "1.1.0"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
 
 "@radix-ui/react-use-callback-ref@1.1.0":
   version "1.1.0"


### PR DESCRIPTION
## 이슈
- #62 

## 구현 내용
- [x] 통계 페이지 레이아웃
- [x] 막대 그래프
- [x] 도넛 그래프

## 상세 내용
![image](https://github.com/user-attachments/assets/c305b9c4-84e1-4579-8dd8-f2314cd13279)

![image](https://github.com/user-attachments/assets/4eab6fa2-97ec-4f70-963d-b56e8529d9e1)


## 고민한 내용
### shadcn chart 커스텀
- 속성으로 변경한 내용
  - 막대 그래프 너비 `barSize={10}`
  - 세로 속성 `YAxis`
  - 도넛 그래프 너비 `innerRadius={70} outerRadius={100}`
  - 툴팁 트리거 `trigger="click"`
- 직접 스타일 변경한 내용
  -  card 스타일 수정해서 디자인 레이아웃에 맞춤
  - `ChartLegend`에 표시되는 내용 생성
```tsx
<span className="flex gap-200 text-detail-1 text-gray-600">
  {itemConfig?.label} <span className="text-primary-normal">{item.payload?.value}</span>
</span>
```

### 빌드 메시지
```
(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
```
- `lazy`로 분리해줌