### PR TITLE
Feature/일기 작성 키워드 강조

### DIFF
--- a/src/pages/write/Write.tsx
+++ b/src/pages/write/Write.tsx
@@ -2,19 +2,100 @@ import { useLocation, useOutletContext } from "react-router-dom";
 import { formatDateWithWeek } from "../../utils/util";
 import { ContextProps } from "./Layout/DiaryWriteFlowLayout";
 import { FADEINANIMATION } from "../../styles/animations";
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import Toggle from "../../components/common/Toggle";
 import Divider from "../../components/common/Divider";
-import { Textarea } from "@/components/ui/textarea";
 
 const Write = () => {
   const location = useLocation();
   const date = location.state.date;
   const { diaryInfo, setDiaryInfo } = useOutletContext<ContextProps>();
+  const editorRef = useRef<HTMLDivElement>(null);
+  const [buttonPosition, setButtonPosition] = useState<{ x: number; y: number } | null>(null);
+  const [selectedText, setSelectedText] = useState<Range | null>(null);
 
   useEffect(() => {
     setDiaryInfo({ ...diaryInfo, date: date });
   }, []);
+
+  useEffect(() => {
+    /**
+     * 선택된 택스트를 감지했을 경우 실행할 함수
+     * @returns
+     */
+    const handleSelectionChange = () => {
+      const selection = window.getSelection();
+      if (!selection || selection.rangeCount === 0) return;
+
+      const range = selection.getRangeAt(0);
+      const rect = range.getBoundingClientRect();
+
+      // 텍스트가 선택된 상태일 때만 버튼 표시
+      if (!selection.isCollapsed) {
+        if (editorRef.current && editorRef.current.contains(range.startContainer)) {
+          const editorRect = editorRef.current.getBoundingClientRect();
+
+          setButtonPosition({
+            x: rect.left - editorRect.left + rect.width / 2 - 30,
+            y: rect.top - editorRect.top + 30,
+          });
+          setSelectedText(range);
+        }
+      } else {
+        setButtonPosition(null);
+      }
+    };
+
+    document.addEventListener("selectionchange", handleSelectionChange);
+
+    return () => {
+      document.removeEventListener("selectionchange", handleSelectionChange);
+    };
+  }, []);
+
+  /**
+   * 선택된 텍스트를 bold 처리하는 함수
+   */
+  const makeBold = () => {
+    if (selectedText) {
+      const selection = window.getSelection();
+      const range = selectedText;
+
+      if (selection && range) {
+        document.execCommand("bold");
+
+        setButtonPosition(null);
+        setSelectedText(null);
+
+        if (editorRef.current) {
+          extractBoldText();
+        }
+      }
+    }
+  };
+
+  /**
+   * 일기 ref에서 b 태그로 강조된 단어 리스트 생성하는 함수
+   * @returns
+   */
+  const extractBoldText = () => {
+    if (!editorRef.current) return;
+
+    const boldTexts: string[] = [];
+    editorRef.current.childNodes.forEach((node) => {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        const element = node as HTMLElement;
+        if (element.tagName === "B") {
+          boldTexts.push(element.textContent || "");
+        }
+      }
+    });
+
+    console.log("Bold Texts:", boldTexts);
+    return boldTexts;
+  };
+
+  const isBold = document.queryCommandState("bold");
 
   return (
     <div className="flex h-full flex-col gap-600 font-Binggrae text-gray-900">
@@ -34,14 +115,41 @@ const Write = () => {
         </div>
       </div>
       <Divider style={FADEINANIMATION[2]} />
-      <Textarea
-        className={`${FADEINANIMATION[3]} flex-grow font-Binggrae text-body-2`}
-        value={diaryInfo.content}
-        onChange={(e) => {
-          setDiaryInfo({ ...diaryInfo, content: e.target.value });
-        }}
-        placeholder="10자 이상 입력해주세요"
-      ></Textarea>
+      <div className="relative flex min-h-[80px] w-full flex-grow">
+        <div
+          ref={editorRef}
+          className={`${
+            FADEINANIMATION[3]
+          } w-full rounded-md border border-input bg-background px-3 py-2 font-Binggrae text-body-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`}
+          contentEditable={true}
+          suppressContentEditableWarning={true}
+          onInput={(e) => {
+            setDiaryInfo({ ...diaryInfo, content: e.currentTarget.textContent || "" });
+          }}
+        ></div>
+        {diaryInfo.content.trim() === "" && (
+          <div className="pointer-events-none absolute left-3 top-2 text-muted-foreground">
+            10자 이상
+          </div>
+        )}
+        {buttonPosition && (
+          <button
+            onClick={makeBold}
+            style={{
+              position: "absolute",
+              top: `${buttonPosition.y}px`,
+              left: `${buttonPosition.x}px`,
+            }}
+            className={`absolute z-50 rounded-md border px-3 py-2 text-sm ${
+              isBold
+                ? "border-blue-500 bg-blue-500 text-white"
+                : "border-gray-300 bg-white text-black"
+            }`}
+          >
+            Bold
+          </button>
+        )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## 이슈
- #46 

## 구현 내용
- [x] 드래그 시 버튼 뜸
- [x] 버튼 누르면 선택된 영역 볼드 처리
- [x] 볼드 처리 된 키워드 배열로 출력

## 상세 내용
![image](https://github.com/user-attachments/assets/c374b3f6-9d61-4336-a9f7-984f6ab0bbf2)
![image](https://github.com/user-attachments/assets/abb9e402-bb73-4236-ad7a-98f0bf16698c)

## 고민한 내용
### 선택된 영역 감지

- selectionchange 이벤트를 사용하여 텍스트 선택을 실시간으로 감지
- window.getSelection()과 getRangeAt(0)를 통해 선택된 텍스트 범위(Range) 획득
- 선택된 영역의 위치를 정확하게 계산하기 위해 getBoundingClientRect()를 활용하여 에디터 내에서의 상대적 위치 계산
- 선택된 영역이 에디터 내부에 있는지 확인하기 위해 editorRef.current.contains(range.startContainer) 조건 검사

### 선택된 영역 볼드 처리

- 버튼 클릭 시 document.execCommand("bold") 명령을 사용하여 선택된 텍스트를 볼드 처리
- 볼드 상태 여부를 document.queryCommandState("bold")로 확인하여 버튼 스타일을 다르게 표시
- 볼드 처리 후 팝업 버튼을 숨기기 위해 setButtonPosition(null)과 setSelectedText(null) 호출
- 선택된 텍스트를 상태로 관리하여 버튼 클릭 시 해당 텍스트를 처리할 수 있도록 구현

### 볼드 처리된 단어 리스트로 가져오기

- extractBoldText 함수를 구현하여 에디터 내 모든 볼드 처리된 텍스트를 추출
- editorRef.current.childNodes를 순회하며 Node.ELEMENT_NODE 타입과 tagName === "B" 조건으로 볼드 텍스트 식별
- 추출된 볼드 텍스트를 배열에 저장하여 콘솔에 출력하고 필요시 반환하도록 구현
- 볼드 처리 이후 자동으로 extractBoldText 함수를 호출하여 키워드 목록 업데이트

### div 요소에 placeholder

- contentEditable div에는 기본 placeholder 속성이 없어 조건부 렌더링으로 구현
- diaryInfo.content.trim() === "" 조건을 사용하여 내용이 비어있을 때만 placeholder 표시
- placeholder의 위치를 에디터와 동일하게 맞추기 위해 absolute 포지셔닝 사용
- pointer-events-none 클래스를 적용하여 placeholder가 사용자 입력을 방해하지 않도록 처리

## 개선할 내용
- `queryCommandState` 메서드가 곧 지원 종료될 예정이라고 함
- 스타일을 전체적인 디자인과 어울리게 수정해야 함