### PR TITLE
Feature: 감정 통계 api

### DIFF
--- a/src/api/api.tsx
+++ b/src/api/api.tsx
@@ -3,6 +3,7 @@ import {
   Diaries,
   DiaryInfo,
   Emotions,
+  EmotionStatsData,
   NewDiaryInfo,
   SearchedDiaries,
   Styles,
@@ -355,6 +356,24 @@ export const postKeyword = async ({ diaryId, keywords }: PostKeywordProps) => {
     const response = await axiosInstance.post(`/api/v1/diaries/${diaryId}/reminiscence`, {
       keywords,
     });
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+};
+
+interface GetEmotionStatsProps {
+  type: "WEEK" | "MONTH";
+  date: string;
+}
+
+export const getEmotionStats = async ({
+  type,
+  date,
+}: GetEmotionStatsProps): Promise<EmotionStatsData> => {
+  const params = { type, date };
+  try {
+    const response = await axiosInstance.get(`/api/v1/stats/emotions`, { params });
     return response.data;
   } catch (error) {
     throw error;

--- a/src/components/pages/stats/EmotionBarChart.tsx
+++ b/src/components/pages/stats/EmotionBarChart.tsx
@@ -50,15 +50,21 @@ const EmotionBarChart = ({ chartData }: EmotionBarChartProps) => {
               dataKey="positive"
               stackId="a"
               fill="var(--color-positive)"
-              radius={[0, 0, 4, 4]}
+              radius={10}
               barSize={10}
             />
-            <Bar dataKey="negative" stackId="a" fill="var(--color-negative)" barSize={10} />
+            <Bar
+              dataKey="negative"
+              stackId="a"
+              fill="var(--color-negative)"
+              radius={10}
+              barSize={10}
+            />
             <Bar
               dataKey="neutral"
               stackId="a"
               fill="var(--color-neutral)"
-              radius={[4, 4, 0, 0]}
+              radius={10}
               barSize={10}
             />
           </BarChart>

--- a/src/pages/stats/Layout/EmotionStatsLayout.tsx
+++ b/src/pages/stats/Layout/EmotionStatsLayout.tsx
@@ -15,12 +15,10 @@ function getWeekRange(date: Date): string {
   const lastDayOfWeek = new Date(firstDayOfWeek);
   lastDayOfWeek.setDate(firstDayOfWeek.getDate() + 6);
 
-  // 날짜를 "yyyy.mm.dd" 형식으로 변환하는 함수
   const formatDate = (d: Date): string => {
-    const year = d.getFullYear();
     const month = String(d.getMonth() + 1).padStart(2, "0");
     const day = String(d.getDate()).padStart(2, "0");
-    return `${year}.${month}.${day}`;
+    return `${month}.${day}`;
   };
 
   // 주간 범위 반환
@@ -61,26 +59,28 @@ const EmotionStatsLayout = () => {
 
   return (
     <div className="flex w-full flex-col items-center justify-center bg-primary-light-1 px-800 py-500 dark:bg-background">
-      <Tabs defaultValue="week" className="w-full text-center font-Binggrae text-body-2">
+      <Tabs defaultValue="WEEK" className="w-full text-center font-Binggrae text-body-2">
         <TabsList className="mb-500 w-full">
-          <TabsTrigger value="week" className="w-full">
+          <TabsTrigger value="WEEK" className="w-full">
             1주
           </TabsTrigger>
-          <TabsTrigger value="month" className="w-full">
+          <TabsTrigger value="MONTH" className="w-full">
             1달
           </TabsTrigger>
         </TabsList>
-        <TabsContent value="week">
+        <TabsContent value="WEEK">
           <EmotionStats
-            value="week"
+            value="WEEK"
+            current={currentWeek}
             text={`${getWeekRange(currentWeek)}`}
             handleNext={handleNextWeek}
             handlePrev={handlePrevWeek}
           />
         </TabsContent>
-        <TabsContent value="month">
+        <TabsContent value="MONTH">
           <EmotionStats
-            value="month"
+            value="MONTH"
+            current={currentMonth}
             text={`${currentMonth.getFullYear()}년 ${months[currentMonth.getMonth()]}월`}
             handleNext={handleNextMonth}
             handlePrev={handlePrevMonth}

--- a/src/types/types.tsx
+++ b/src/types/types.tsx
@@ -74,3 +74,20 @@ export type Emotion = {
   name: string;
   koreanName: string;
 };
+
+//감정 통계 정보
+export type EmotionStatsData = {
+  barData: EmotionBarData;
+  pieData: EmotionPieData;
+};
+
+//감정 막대 그래프 정보
+export type EmotionBarData = {
+  dataKey: number;
+  positive: number;
+  neutral: number;
+  negative: number;
+}[];
+
+//감정 도넛 그래프 정보
+export type EmotionPieData = { emotion: string; diaryCount: number }[];


### PR DESCRIPTION
## 이슈
- #62 

## 구현 내용
- [x] 감정 통계 api
- [x] 막대그래프 스타일

## 상세 내용
![image](https://github.com/user-attachments/assets/4eb85d0f-aa4b-48d7-85b6-b812071748a5)

## 고민한 내용
### 포맷팅
- api 데이터와 shadcn charts에서 요구하는 내용이 다름
- 그래프 x축 고정하기 위해 더미 데이터 필요
- `formatToProps` 함수를 둬서 원하는 작업을 모두 끝내고 `charts`의 `Props`로 전달

## 개선할 내용
- `formatToProps`의 `if-else`문 여러번 사용