### PR TITLE
Feature: 일기 가중치 단어 추가

### DIFF
--- a/src/api/api.tsx
+++ b/src/api/api.tsx
@@ -261,6 +261,7 @@ interface ModifiedDiaryProps {
   diaryId: string;
   content: string;
   isPublic: boolean;
+  weightedContents: string[];
 }
 
 /**
@@ -268,9 +269,14 @@ interface ModifiedDiaryProps {
  * @param param0 ModifyDiaryProps
  * @returns
  */
-export const putModifiedDiary = async ({ diaryId, content, isPublic }: ModifiedDiaryProps) => {
+export const putModifiedDiary = async ({
+  diaryId,
+  content,
+  isPublic,
+  weightedContents,
+}: ModifiedDiaryProps) => {
   try {
-    await axiosInstance.put(`/api/v1/diaries/${diaryId}`, { content, isPublic });
+    await axiosInstance.put(`/api/v1/diaries/${diaryId}`, { content, isPublic, weightedContents });
   } catch (error) {
     throw error;
   }

--- a/src/components/common/EmotionTag.stories.tsx
+++ b/src/components/common/EmotionTag.stories.tsx
@@ -1,14 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { fn } from "@storybook/test";
-import Tag from "./Tag";
+import EmotionTag from "./EmotionTag";
 
-const meta: Meta<typeof Tag> = {
-  component: Tag,
+const meta: Meta<typeof EmotionTag> = {
+  component: EmotionTag,
   tags: ["autodocs"],
 };
 
 export default meta;
-type Story = StoryObj<typeof Tag>;
+type Story = StoryObj<typeof EmotionTag>;
 
 export const Primary: Story = {
   args: {

--- a/src/components/common/EmotionTag.tsx
+++ b/src/components/common/EmotionTag.tsx
@@ -1,4 +1,4 @@
-interface TagProps {
+interface EmotionTagProps {
   text: string;
   selected: boolean;
   onClick?: () => void;
@@ -11,7 +11,7 @@ interface TagProps {
  * @param onClick 태그 클릭 콜백 함수
  * @returns
  */
-const Tag = ({ text, selected, onClick }: TagProps) => {
+const EmotionTag = ({ text, selected, onClick }: EmotionTagProps) => {
   return (
     <button
       className={`h-fit w-fit whitespace-nowrap rounded-full px-400 py-200 font-Binggrae text-detail-1 font-regular ${selected ? "bg-primary-medium text-background" : "bg-primary-light-2 text-primary-normal dark:bg-gray-600 dark:text-gray-200"}`}
@@ -20,4 +20,4 @@ const Tag = ({ text, selected, onClick }: TagProps) => {
   );
 };
 
-export default Tag;
+export default EmotionTag;

--- a/src/components/common/KeywordTag.stories.tsx
+++ b/src/components/common/KeywordTag.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import KeywordTag from "./KeywordTag";
+import { fn } from "@storybook/test";
+
+const meta: Meta<typeof KeywordTag> = {
+  component: KeywordTag,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof KeywordTag>;
+
+export const Primary: Story = {
+  args: {
+    text: "Text",
+    onClick: fn(),
+  },
+};

--- a/src/components/common/KeywordTag.tsx
+++ b/src/components/common/KeywordTag.tsx
@@ -1,0 +1,20 @@
+import { Tag } from "lucide-react";
+
+interface KeywordTagProps {
+  text: string;
+  onClick: () => void;
+}
+
+const KeywordTag = ({ text, onClick }: KeywordTagProps) => {
+  return (
+    <button
+      className="flex items-center justify-center gap-300 whitespace-nowrap rounded-full bg-primary-light-2 px-400 py-200 font-Binggrae text-detail-1 font-regular text-primary-normal dark:bg-gray-600 dark:text-gray-200"
+      onClick={onClick}
+    >
+      <Tag height={12} width={12} />
+      {text}
+    </button>
+  );
+};
+
+export default KeywordTag;

--- a/src/components/pages/diary/Content.tsx
+++ b/src/components/pages/diary/Content.tsx
@@ -1,4 +1,4 @@
-import Tag from "../../common/Tag";
+import EmotionTag from "../../common/EmotionTag";
 import HeartIcon from "../../../assets/svg/heart.svg?react";
 import { useEffect, useRef, useState } from "react";
 import { addLike, removeLike } from "../../../api/api";
@@ -90,7 +90,7 @@ const Content = ({ date, emotion, likedCount, isLiked, content, setAppbar }: Con
           <div className="flex flex-col gap-300">
             <div className="font-BinggraeBold text-title-2">{date}</div>
             <div>
-              <Tag text={tagsMap[emotion]} selected={true}></Tag>
+              <EmotionTag text={tagsMap[emotion]} selected={true}></EmotionTag>
             </div>
           </div>
           <div

--- a/src/components/pages/diary/Content.tsx
+++ b/src/components/pages/diary/Content.tsx
@@ -22,7 +22,7 @@ const tagsMap: { [key: string]: string } = {
   ANGER: "분노",
   FEAR: "공포",
   DISGUST: "혐오",
-  NONE: "NONE",
+  NONE: "무난",
   SHAMEhy: "수치",
   SURPRISE: "놀람",
   CURIOSITY: "궁금",

--- a/src/components/pages/write/ReviewContent.tsx
+++ b/src/components/pages/write/ReviewContent.tsx
@@ -1,4 +1,4 @@
-import Tag from "../../common/Tag";
+import EmotionTag from "../../common/EmotionTag";
 import ImageCarousel from "../diary/ImageCarousel";
 import HeartIcon from "../../../assets/svg/heart.svg?react";
 import { DiaryImage } from "../../../types/types";
@@ -41,7 +41,7 @@ const ReviewContent = ({ date, emotion, likedCount, isLiked, content, images }: 
         <div className="flex flex-col gap-300">
           <div className="font-BinggraeBold text-title-2">{date}</div>
           <div>
-            <Tag text={tagsMap[emotion]} selected={true}></Tag>
+            <EmotionTag text={tagsMap[emotion]} selected={true}></EmotionTag>
           </div>
         </div>
         <div

--- a/src/pages/Album.tsx
+++ b/src/pages/Album.tsx
@@ -1,4 +1,4 @@
-import Tag from "../components/common/Tag";
+import EmotionTag from "../components/common/EmotionTag";
 import SearchBar from "../components/pages/album/SearchBar";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -154,7 +154,7 @@ const Album = () => {
             className={`absolute flex w-full gap-400 overflow-scroll bg-background py-500 transition-all duration-300 ${isTagsVisible ? "top-[3.3rem] opacity-100" : "pointer-events-none top-10 opacity-0"}`}
           >
             {tags.map((tag, index) => (
-              <Tag
+              <EmotionTag
                 key={index}
                 text={tag}
                 selected={selectedTag === tag}

--- a/src/pages/diary/Diary.tsx
+++ b/src/pages/diary/Diary.tsx
@@ -117,6 +117,7 @@ const Diary = ({ diaryInfo, carouselHeight, isMyDiary, retry }: DiaryProps) => {
             diaryId: diaryInfo.diaryId,
             content: diaryInfo.content,
             isPublic: newIsPublic,
+            weightedContents: diaryInfo.weightedContents,
           });
         } catch (error) {
           throw error;

--- a/src/pages/write/Layout/DiaryWriteFlowLayout.tsx
+++ b/src/pages/write/Layout/DiaryWriteFlowLayout.tsx
@@ -27,10 +27,8 @@ const pageOrder = [
 
 export interface ContextProps {
   diaryInfo: NewDiaryInfo;
-  setDiaryInfo: Function;
+  setDiaryInfo: React.Dispatch<React.SetStateAction<NewDiaryInfo>>;
   diaryId: string;
-  keywords: string[];
-  setKeywords: Function;
 }
 
 const DiaryWriteFlowLayout = () => {
@@ -43,8 +41,8 @@ const DiaryWriteFlowLayout = () => {
     content: "",
     isPublic: true,
     style: "",
+    weightedContents: [],
   });
-  const [keywords, setKeywords] = useState([]);
 
   const onClickNext = async () => {
     const currentIndex = pageOrder.indexOf(location.pathname);
@@ -120,7 +118,7 @@ const DiaryWriteFlowLayout = () => {
     <MobileLayout>
       <Appbar text="일기 작성" backHandler={handleBack}></Appbar>
       <div className="flex-grow overflow-scroll px-800 py-300">
-        <Outlet context={{ diaryInfo, setDiaryInfo, diaryId, keywords, setKeywords }} />
+        <Outlet context={{ diaryInfo, setDiaryInfo, diaryId }} />
       </div>
       <div className="my-4 flex justify-center">
         <Button

--- a/src/pages/write/Layout/DiaryWriteFlowLayout.tsx
+++ b/src/pages/write/Layout/DiaryWriteFlowLayout.tsx
@@ -29,6 +29,8 @@ export interface ContextProps {
   diaryInfo: NewDiaryInfo;
   setDiaryInfo: React.Dispatch<React.SetStateAction<NewDiaryInfo>>;
   diaryId: string;
+  keywords: string[];
+  setKeywords: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
 const DiaryWriteFlowLayout = () => {

--- a/src/pages/write/Modify.tsx
+++ b/src/pages/write/Modify.tsx
@@ -1,19 +1,22 @@
 import { useLocation, useNavigate } from "react-router-dom";
 import { formatDateWithWeek } from "../../utils/util";
 import { FADEINANIMATION } from "../../styles/animations";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Divider from "../../components/common/Divider";
-import { Textarea } from "@/components/ui/textarea";
 import Appbar from "@/components/common/Appbar";
 import MobileLayout from "../Layout/MobileLayout";
 import Button from "@/components/common/Button";
 import { DiaryInfo } from "@/types/types";
 import { putModifiedDiary } from "@/api/api";
+import KeywordTag from "@/components/common/KeywordTag";
 
 const Modify = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const [diaryInfo, setDiaryInfo] = useState<DiaryInfo | null>(null);
+  const [selectedText, setSelectedText] = useState<Range | null>(null);
+  const editorRef = useRef<HTMLDivElement>(null);
+  const [buttonPosition, setButtonPosition] = useState<{ x: number; y: number } | null>(null);
 
   const onClickModify = async () => {
     if (diaryInfo) {
@@ -22,6 +25,7 @@ const Modify = () => {
           diaryId: diaryInfo.diaryId,
           content: diaryInfo.content,
           isPublic: diaryInfo.isPublic,
+          weightedContents: diaryInfo.weightedContents,
         });
         navigate(`/diary/${diaryInfo.diaryId}`, { state: { isModified: true }, replace: true });
       } catch (error) {
@@ -30,8 +34,89 @@ const Modify = () => {
     }
   };
 
+  /**
+   * 선택된 텍스트를 키워드로 추가하는 함수
+   */
+  const addKeyword = () => {
+    if (selectedText) {
+      const selection = window.getSelection();
+
+      if (selection) {
+        const text = selection.toString();
+        setDiaryInfo((prev) => {
+          if (!prev) return prev;
+          return { ...prev, weightedContents: [...prev.weightedContents, text] };
+        });
+        setButtonPosition(null);
+        setSelectedText(null);
+      }
+    }
+  };
+
+  /**
+   * 키워드 태그 선택 시 삭제하는 함수
+   * @param keywordToRemove
+   */
+  const handleKeywordClick = (keywordToRemove: string) => {
+    setDiaryInfo((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        weightedContents: prev.weightedContents.filter((keyword) => keyword !== keywordToRemove),
+      };
+    });
+  };
+
+  /**
+   * 마운트 시 diaryInfo 반영
+   */
   useEffect(() => {
-    setDiaryInfo(location.state.diaryInfo);
+    const diaryInitInfo = location.state.diaryInfo;
+    setDiaryInfo(diaryInitInfo);
+  }, []);
+
+  /**
+   * diaryInfo 변경 시 textContent 변경
+   */
+  useEffect(() => {
+    if (editorRef.current && diaryInfo) {
+      editorRef.current.textContent = diaryInfo.content;
+    }
+  }, [diaryInfo]);
+
+  useEffect(() => {
+    /**
+     * 선택된 택스트를 감지했을 경우 실행할 함수
+     * @returns
+     */
+    const handleSelectionChange = () => {
+      const selection = window.getSelection();
+      if (!selection || selection.rangeCount === 0) return;
+
+      const range = selection.getRangeAt(0);
+      const rect = range.getBoundingClientRect();
+
+      // 텍스트가 선택된 상태일 때만 버튼 표시
+      if (!selection.isCollapsed) {
+        if (editorRef.current && editorRef.current.contains(range.startContainer)) {
+          const editorRect = editorRef.current.getBoundingClientRect();
+
+          setButtonPosition({
+            x: rect.left - editorRect.left + rect.width / 2 - 30,
+            y: rect.top - editorRect.top + 30,
+          });
+          setSelectedText(range);
+        }
+      } else {
+        setButtonPosition(null);
+      }
+    };
+
+    document.addEventListener("selectionchange", handleSelectionChange);
+
+    return () => {
+      document.removeEventListener("selectionchange", handleSelectionChange);
+    };
   }, []);
 
   return (
@@ -39,19 +124,56 @@ const Modify = () => {
       <Appbar text="일기 수정" backHandler={() => navigate(-1)}></Appbar>
       <div className="flex-grow overflow-scroll px-800 py-300">
         {diaryInfo && (
-          <div className="flex h-full flex-col gap-600 font-Binggrae text-gray-900">
+          <div className="flex h-full flex-col gap-600 font-Binggrae text-gray-900 dark:text-gray-50">
             <div className={`${FADEINANIMATION[0]} font-BinggraeBold text-title-2`}>
               {formatDateWithWeek(diaryInfo.date)}
             </div>
-            <Divider style={FADEINANIMATION[1]} />
-            <Textarea
-              className={`${FADEINANIMATION[2]} flex-grow font-Binggrae text-body-2`}
-              value={diaryInfo.content}
-              onChange={(e) => {
-                setDiaryInfo({ ...diaryInfo, content: e.target.value });
-              }}
-              placeholder="10자 이상 입력해주세요"
-            ></Textarea>
+            <div className={`${FADEINANIMATION[1]} flex items-center gap-300 text-body-2`}>
+              <div className="whitespace-nowrap py-200 font-Binggrae text-gray-500">키워드</div>
+              <div className="flex gap-400 overflow-scroll">
+                {diaryInfo.weightedContents.map((keyword) => (
+                  <KeywordTag
+                    key={keyword}
+                    text={keyword}
+                    onClick={() => handleKeywordClick(keyword)}
+                  ></KeywordTag>
+                ))}
+              </div>
+            </div>
+            <Divider style={FADEINANIMATION[2]} />
+            <div className="relative flex min-h-[80px] w-full flex-grow">
+              <div
+                ref={editorRef}
+                className={`${
+                  FADEINANIMATION[3]
+                } w-full overflow-scroll rounded-md border border-input bg-background px-3 py-2 font-Binggrae text-body-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`}
+                contentEditable={true}
+                suppressContentEditableWarning={true}
+                onInput={(e) => {
+                  setDiaryInfo({ ...diaryInfo, content: e.currentTarget.textContent || "" });
+                }}
+              ></div>
+              {diaryInfo.content.trim() === "" && (
+                <div
+                  className={`${FADEINANIMATION[3]} pointer-events-none absolute left-3 top-2 text-muted-foreground`}
+                >
+                  10자 이상 작성해주세요. 드래그해서 강조할 단어를 최대 5개 선택할 수 있어요.
+                </div>
+              )}
+              {buttonPosition && (
+                <button
+                  onClick={addKeyword}
+                  style={{
+                    position: "absolute",
+                    top: `${buttonPosition.y}px`,
+                    left: `${buttonPosition.x}px`,
+                  }}
+                  className={`absolute z-50 rounded-md border bg-primary-medium px-3 py-2 text-sm text-background`}
+                >
+                  강조하기
+                </button>
+              )}
+            </div>
           </div>
         )}
       </div>

--- a/src/pages/write/Write.tsx
+++ b/src/pages/write/Write.tsx
@@ -16,7 +16,7 @@ const Write = () => {
   const [selectedText, setSelectedText] = useState<Range | null>(null);
 
   /**
-   * 마운트 시 date 반경
+   * 마운트 시 date, content 반영
    */
   useEffect(() => {
     setDiaryInfo({ ...diaryInfo, date: date });

--- a/src/pages/write/Write.tsx
+++ b/src/pages/write/Write.tsx
@@ -14,8 +14,10 @@ const Write = () => {
   const editorRef = useRef<HTMLDivElement>(null);
   const [buttonPosition, setButtonPosition] = useState<{ x: number; y: number } | null>(null);
   const [selectedText, setSelectedText] = useState<Range | null>(null);
-  const [keywords, setKeywords] = useState<string[]>([]);
 
+  /**
+   * 마운트 시 date 반경
+   */
   useEffect(() => {
     setDiaryInfo({ ...diaryInfo, date: date });
     if (editorRef.current) {
@@ -59,16 +61,16 @@ const Write = () => {
   }, []);
 
   /**
-   * 선택된 텍스트를 bold 처리하는 함수
+   * 선택된 텍스트를 키워드로 추가하는 함수
    */
-  const makeBold = () => {
+  const addKeyword = () => {
     if (selectedText) {
       const selection = window.getSelection();
 
       if (selection) {
         const text = selection.toString();
-        setKeywords((prev) => {
-          return text ? [...prev, text] : prev;
+        setDiaryInfo((prev) => {
+          return { ...prev, weightedContents: [...prev.weightedContents, text] };
         });
         setButtonPosition(null);
         setSelectedText(null);
@@ -76,8 +78,17 @@ const Write = () => {
     }
   };
 
+  /**
+   * 키워드 태그 선택 시 삭제하는 함수
+   * @param keywordToRemove
+   */
   const handleKeywordClick = (keywordToRemove: string) => {
-    setKeywords((prev) => prev.filter((keyword) => keyword !== keywordToRemove));
+    setDiaryInfo((prev) => {
+      return {
+        ...prev,
+        weightedContents: prev.weightedContents.filter((keyword) => keyword !== keywordToRemove),
+      };
+    });
   };
 
   return (
@@ -100,8 +111,12 @@ const Write = () => {
       <div className={`${FADEINANIMATION[2]} flex items-center gap-300 text-body-2`}>
         <div className="whitespace-nowrap py-200 font-Binggrae text-gray-500">키워드</div>
         <div className="flex gap-400 overflow-scroll">
-          {keywords.map((keyword) => (
-            <KeywordTag text={keyword} onClick={() => handleKeywordClick(keyword)}></KeywordTag>
+          {diaryInfo.weightedContents.map((keyword) => (
+            <KeywordTag
+              key={keyword}
+              text={keyword}
+              onClick={() => handleKeywordClick(keyword)}
+            ></KeywordTag>
           ))}
         </div>
       </div>
@@ -127,7 +142,7 @@ const Write = () => {
         )}
         {buttonPosition && (
           <button
-            onClick={makeBold}
+            onClick={addKeyword}
             style={{
               position: "absolute",
               top: `${buttonPosition.y}px`,

--- a/src/pages/write/Write.tsx
+++ b/src/pages/write/Write.tsx
@@ -5,6 +5,7 @@ import { FADEINANIMATION } from "../../styles/animations";
 import { useEffect, useRef, useState } from "react";
 import Toggle from "../../components/common/Toggle";
 import Divider from "../../components/common/Divider";
+import KeywordTag from "@/components/common/KeywordTag";
 
 const Write = () => {
   const location = useLocation();
@@ -13,6 +14,7 @@ const Write = () => {
   const editorRef = useRef<HTMLDivElement>(null);
   const [buttonPosition, setButtonPosition] = useState<{ x: number; y: number } | null>(null);
   const [selectedText, setSelectedText] = useState<Range | null>(null);
+  const [keywords, setKeywords] = useState<string[]>([]);
 
   useEffect(() => {
     setDiaryInfo({ ...diaryInfo, date: date });
@@ -62,43 +64,21 @@ const Write = () => {
   const makeBold = () => {
     if (selectedText) {
       const selection = window.getSelection();
-      const range = selectedText;
 
-      if (selection && range) {
-        document.execCommand("bold");
-
+      if (selection) {
+        const text = selection.toString();
+        setKeywords((prev) => {
+          return text ? [...prev, text] : prev;
+        });
         setButtonPosition(null);
         setSelectedText(null);
-
-        if (editorRef.current) {
-          extractBoldText();
-        }
       }
     }
   };
 
-  /**
-   * 일기 ref에서 b 태그로 강조된 단어 리스트 생성하는 함수
-   * @returns
-   */
-  const extractBoldText = () => {
-    if (!editorRef.current) return;
-
-    const boldTexts: string[] = [];
-    editorRef.current.childNodes.forEach((node) => {
-      if (node.nodeType === Node.ELEMENT_NODE) {
-        const element = node as HTMLElement;
-        if (element.tagName === "B") {
-          boldTexts.push(element.textContent || "");
-        }
-      }
-    });
-
-    console.log("Bold Texts:", boldTexts);
-    return boldTexts;
+  const handleKeywordClick = (keywordToRemove: string) => {
+    setKeywords((prev) => prev.filter((keyword) => keyword !== keywordToRemove));
   };
-
-  const isBold = document.queryCommandState("bold");
 
   return (
     <div className="flex h-full flex-col gap-600 font-Binggrae text-gray-900 dark:text-gray-50">
@@ -106,7 +86,7 @@ const Write = () => {
         {formatDateWithWeek(date)}
       </div>
       <div className={`${FADEINANIMATION[1]} flex items-center gap-300 text-body-2`}>
-        <div className="font-Binggrae text-gray-500">공개 여부</div>
+        <div className="py-200 font-Binggrae text-gray-500">공개 여부</div>
         <div className="flex items-center justify-center rounded-50 bg-primary-light-2 px-300 py-200 dark:bg-primary-medium">
           {diaryInfo.isPublic ? "공개" : "비공개"}
         </div>
@@ -117,13 +97,21 @@ const Write = () => {
           ></Toggle>
         </div>
       </div>
-      <Divider style={FADEINANIMATION[2]} />
+      <div className={`${FADEINANIMATION[2]} flex items-center gap-300 text-body-2`}>
+        <div className="whitespace-nowrap py-200 font-Binggrae text-gray-500">키워드</div>
+        <div className="flex gap-400 overflow-scroll">
+          {keywords.map((keyword) => (
+            <KeywordTag text={keyword} onClick={() => handleKeywordClick(keyword)}></KeywordTag>
+          ))}
+        </div>
+      </div>
+      <Divider style={FADEINANIMATION[3]} />
       <div className="relative flex min-h-[80px] w-full flex-grow">
         <div
           ref={editorRef}
           className={`${
-            FADEINANIMATION[3]
-          } w-full rounded-md border border-input bg-background px-3 py-2 font-Binggrae text-body-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`}
+            FADEINANIMATION[4]
+          } w-full overflow-scroll rounded-md border border-input bg-background px-3 py-2 font-Binggrae text-body-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`}
           contentEditable={true}
           suppressContentEditableWarning={true}
           onInput={(e) => {
@@ -132,9 +120,9 @@ const Write = () => {
         ></div>
         {diaryInfo.content.trim() === "" && (
           <div
-            className={`${FADEINANIMATION[3]} pointer-events-none absolute left-3 top-2 text-muted-foreground`}
+            className={`${FADEINANIMATION[4]} pointer-events-none absolute left-3 top-2 text-muted-foreground`}
           >
-            10자 이상 작성해주세요. 드래그해서 강조할 단어를 선택할 수 있어요.
+            10자 이상 작성해주세요. 드래그해서 강조할 단어를 최대 5개 선택할 수 있어요.
           </div>
         )}
         {buttonPosition && (
@@ -145,13 +133,9 @@ const Write = () => {
               top: `${buttonPosition.y}px`,
               left: `${buttonPosition.x}px`,
             }}
-            className={`absolute z-50 rounded-md border px-3 py-2 text-sm ${
-              isBold
-                ? "border-blue-500 bg-blue-500 text-white"
-                : "border-gray-300 bg-white text-black"
-            }`}
+            className={`absolute z-50 rounded-md border bg-primary-medium px-3 py-2 text-sm text-background`}
           >
-            Bold
+            강조하기
           </button>
         )}
       </div>

--- a/src/types/types.tsx
+++ b/src/types/types.tsx
@@ -16,6 +16,7 @@ export type NewDiaryInfo = {
   content: string;
   style: string;
   isPublic: boolean;
+  weightedContents: string[];
 };
 
 //일기 조회 정보

--- a/src/types/types.tsx
+++ b/src/types/types.tsx
@@ -30,6 +30,7 @@ export type DiaryInfo = {
   isPublic: boolean;
   date: string;
   images: DiaryImage[];
+  weightedContents: string[];
 };
 
 //일기 조회 이미지


### PR DESCRIPTION
## 이슈
- #46 
- #40 
- #30 

## 구현 내용
- [x] 감정 태그, 키워드 태그 구분
- [x] 드래그로 강조 시 키워드 목록에 추가하는 방식으로 변경
- [x] 일기 작성, 수정 시 키워드 목록 조회 가능하도록 변경

## 상세 내용
### 일기 작성
![image](https://github.com/user-attachments/assets/9d50519b-10a7-4f68-b350-32196341dbfc)

### 일기 수정
![image](https://github.com/user-attachments/assets/28c1d541-4925-4ae9-8efc-9b3adfec57d1)

## 고민한 내용
### 키워드는 어디에 표시하는것이 좋을까
- 콘텐츠에 bold로 표시하는 것이 초기 기획
- 이를 처리하여 조회, 수정 페이지에 표시하는 것이 이미 만들어진 뼈대에서는 고치기 어려움...
- 상단에 키워드 목록을 표시하도록 변경