### PR TITLE
Feature/longpress 개선, 쿼리 디버그, 통계 fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-tabs": "^1.1.1",
     "@tanstack/react-query": "^5.59.20",
+    "@tanstack/react-query-devtools": "^5.60.5",
     "autoprefixer": "^10.4.20",
     "axios": "^1.7.7",
     "class-variance-authority": "^0.7.0",

--- a/src/components/pages/diary/ImageCarousel.tsx
+++ b/src/components/pages/diary/ImageCarousel.tsx
@@ -18,10 +18,18 @@ const ImageCarousel = ({ images, canAdd, onLongPress }: ImageCarouselProps) => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const longPressTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const isDraggingRef = useRef(false);
 
   const startLongPress = (img: DiaryImage) => {
     if (onLongPress) {
-      longPressTimerRef.current = setTimeout(() => onLongPress(img), 500);
+      isDraggingRef.current = false;
+
+      longPressTimerRef.current = setTimeout(() => {
+        if (!isDraggingRef.current) {
+          onLongPress(img);
+        }
+      }, 500);
     }
   };
 
@@ -32,29 +40,37 @@ const ImageCarousel = ({ images, canAdd, onLongPress }: ImageCarouselProps) => {
     }
   };
 
+  const handleMouseMove = () => {
+    isDraggingRef.current = true;
+    cancelLongPress();
+  };
+
   const handleScroll = () => {
     if (containerRef.current) {
       const scrollPosition = containerRef.current.scrollLeft;
       const imageWidth = containerRef.current.offsetWidth;
       const index = Math.round(scrollPosition / imageWidth);
       setCurrentIndex(index);
+
+      cancelLongPress();
     }
   };
 
   useEffect(() => {
     const container = containerRef.current;
+
     if (container) {
+      container.addEventListener("mousemove", handleMouseMove);
       container.addEventListener("scroll", handleScroll);
     }
 
     return () => {
       if (container) {
+        container.removeEventListener("mousemove", handleMouseMove);
         container.removeEventListener("scroll", handleScroll);
       }
     };
   }, []);
-
-  const [isLoaded, setIsLoaded] = useState(false);
 
   return (
     <div>

--- a/src/components/pages/write/ReviewContent.tsx
+++ b/src/components/pages/write/ReviewContent.tsx
@@ -18,7 +18,7 @@ const tagsMap: { [key: string]: string } = {
   ANGER: "분노",
   FEAR: "공포",
   DISGUST: "혐오",
-  NONE: "NONE",
+  NONE: "무난",
   SHAMEhy: "수치",
   SURPRISE: "놀람",
   CURIOSITY: "궁금",

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 const queryClient = new QueryClient();
 
@@ -10,6 +11,7 @@ createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <App />
+      <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   </StrictMode>
 );

--- a/src/pages/Album.tsx
+++ b/src/pages/Album.tsx
@@ -65,6 +65,7 @@ const Album = () => {
     },
     select: (data) => (data.pages ?? []).flatMap((page) => page.content),
     initialPageParam: 0,
+    staleTime: 1000 * 60 * 5,
   });
 
   /**

--- a/src/pages/Explore.tsx
+++ b/src/pages/Explore.tsx
@@ -55,6 +55,7 @@ const Explore = () => {
     },
     select: (data) => (data.pages ?? []).flatMap((page) => page.content),
     initialPageParam: 0,
+    staleTime: 1000 * 60 * 5, // 데이터가 5분 동안은 최신 상태로 간주하여 캐시된 데이터를 재사용
   });
 
   /**

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -24,7 +24,7 @@ const Mypage = () => {
           />
         </div>
         <Divider />
-        <button className="w-full text-start" onClick={() => navigate("stats")}>
+        <button className="w-full text-start" onClick={() => navigate("stats/emotion")}>
           통계
         </button>
         <Divider />

--- a/src/pages/diary/Diary.tsx
+++ b/src/pages/diary/Diary.tsx
@@ -12,6 +12,7 @@ import DeleteDiarySettings from "@/components/common/BottomSheet/DeleteDiarySett
 import DiaryImageSettings from "@/components/common/BottomSheet/DiaryImageSettings";
 import DeleteImageSettings from "@/components/common/BottomSheet/DeleteImageSettings";
 import { toast, Toaster } from "sonner";
+import RoutePaths from "@/constants/routePath";
 
 interface DiaryProps {
   diaryInfo: DiaryInfo;
@@ -52,6 +53,26 @@ const Diary = ({ diaryInfo, carouselHeight, isMyDiary, retry }: DiaryProps) => {
   const [currentHeight] = useState(carouselHeight - 50);
   const [isAppbarVisible, setIsAppbarVisible] = useState(true);
 
+  const browserPreventEvent = (event: () => void) => {
+    history.pushState(null, "", location.pathname);
+    event();
+  };
+
+  useEffect(() => {
+    const handlePopstate = () => {
+      browserPreventEvent(() => {
+        if (location.state && location.state.from === RoutePaths.diaryDraw) {
+          navigate("/");
+        } else navigate(-2);
+      });
+    };
+    history.pushState(null, "", location.pathname);
+    window.addEventListener("popstate", handlePopstate);
+    return () => {
+      window.removeEventListener("popstate", handlePopstate);
+    };
+  }, []);
+
   useEffect(() => {
     return () => {
       if (timeoutRef.current) {
@@ -78,6 +99,11 @@ const Diary = ({ diaryInfo, carouselHeight, isMyDiary, retry }: DiaryProps) => {
         throw error;
       }
     }
+  };
+
+  const handleBackClick = () => {
+    if (location.state && location.state.from === RoutePaths.diaryDraw) navigate("/");
+    else navigate(-1);
   };
 
   const handleMenuClick = () => {
@@ -159,7 +185,7 @@ const Diary = ({ diaryInfo, carouselHeight, isMyDiary, retry }: DiaryProps) => {
       {isAppbarVisible && (
         <div className={`fixed top-0 z-50 w-full animate-fadeInSlideDown`}>
           <Appbar
-            backHandler={() => navigate(-1)}
+            backHandler={handleBackClick}
             menuHandler={isMyDiary ? handleMenuClick : undefined}
           />
         </div>

--- a/src/pages/stats/Fallback/StatsFallback.stories.tsx
+++ b/src/pages/stats/Fallback/StatsFallback.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import StatsFallback from "./StatsFallback";
+
+const meta: Meta<typeof StatsFallback> = {
+  component: StatsFallback,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof StatsFallback>;
+
+export const Primary: Story = {
+  args: {},
+};

--- a/src/pages/stats/Fallback/StatsFallback.tsx
+++ b/src/pages/stats/Fallback/StatsFallback.tsx
@@ -1,0 +1,18 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+const StatsFallback = () => {
+  return (
+    <div className="flex w-full flex-col bg-primary-light-1 px-800 py-500 dark:bg-background">
+      <Skeleton className="mb-500 h-10 w-full rounded-md p-1" />
+      <div className="flex flex-col gap-500">
+        <Skeleton className="h-10 w-full" />
+        <div className="flex flex-col gap-800">
+          <Skeleton className="h-80 w-full rounded-300" />
+          <Skeleton className="h-80 w-full rounded-300" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default StatsFallback;

--- a/src/pages/stats/Layout/StatsLayout.tsx
+++ b/src/pages/stats/Layout/StatsLayout.tsx
@@ -1,8 +1,6 @@
 import Appbar from "@/components/common/Appbar";
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
-import EmotionStats from "./EmotionStatsLayout";
-import KeywordStats from "./KeywordStatsLayout";
+import { Outlet, useNavigate } from "react-router-dom";
 
 const buttonPositions = {
   emotion: "left-0",
@@ -53,7 +51,7 @@ const StatsLayout = () => {
         <div className="absolute bottom-0 -z-10 h-[1px] w-full bg-gray-100 dark:bg-gray-500" />
       </div>
 
-      {selected === "emotion" ? <EmotionStats /> : <KeywordStats />}
+      <Outlet />
     </div>
   );
 };

--- a/src/pages/write/Draw.tsx
+++ b/src/pages/write/Draw.tsx
@@ -2,19 +2,9 @@ import { useOutletContext } from "react-router-dom";
 import dummy from "../../assets/dummy/_Image.png";
 import { FADEINANIMATION } from "../../styles/animations";
 import { ContextProps } from "./Layout/DiaryWriteFlowLayout";
-import { useEffect } from "react";
-import { postKeyword } from "@/api/api";
 
 const Draw = () => {
-  const { diaryId, keywords } = useOutletContext<ContextProps>();
-
-  useEffect(() => {
-    const setKeywordToDiary = async () => {
-      await postKeyword({ diaryId: diaryId, keywords: keywords });
-    };
-
-    if (diaryId !== "0") setKeywordToDiary();
-  }, [diaryId]);
+  const { diaryId } = useOutletContext<ContextProps>();
 
   return (
     <div className="items-centergap-[2rem] flex h-full flex-col justify-center font-Binggrae text-gray-900 dark:text-gray-50">

--- a/src/pages/write/Layout/DiaryModifyFlowLayout.tsx
+++ b/src/pages/write/Layout/DiaryModifyFlowLayout.tsx
@@ -21,8 +21,9 @@ const DiaryModifyFlowLayout = () => {
         .catch((error) => {
           throw error;
         });
-      navigate(`/diary/${diaryID}/draw`);
-    } else if (location.pathname === `/diary/${diaryID}/draw`) navigate(`/diary/${diaryID}`);
+      navigate(`/diary/${diaryID}/draw`, { replace: true });
+    } else if (location.pathname === `/diary/${diaryID}/draw`)
+      navigate(`/diary/${diaryID}`, { replace: true });
   };
 
   const handleActive = () => {

--- a/src/pages/write/Layout/DiaryWriteFlowLayout.tsx
+++ b/src/pages/write/Layout/DiaryWriteFlowLayout.tsx
@@ -2,8 +2,8 @@ import { Outlet, useBlocker, useLocation, useNavigate } from "react-router-dom";
 import Appbar from "../../../components/common/Appbar";
 import Button from "../../../components/common/Button";
 import RoutePaths from "../../../constants/routePath";
-import { useState } from "react";
-import { createDiaryAndGetId } from "../../../api/api";
+import { useEffect, useState } from "react";
+import { createDiaryAndGetId, postKeyword } from "../../../api/api";
 import { useErrorBoundary } from "react-error-boundary";
 import MobileLayout from "../../Layout/MobileLayout";
 import { getTodayDate } from "../../../utils/util";
@@ -38,6 +38,7 @@ const DiaryWriteFlowLayout = () => {
   const location = useLocation();
   const { showBoundary } = useErrorBoundary();
   const [diaryId, setDiaryId] = useState("0");
+  const [keywords, setKeywords] = useState([]);
   const [diaryInfo, setDiaryInfo] = useState<NewDiaryInfo>({
     date: getTodayDate(),
     content: "",
@@ -49,7 +50,7 @@ const DiaryWriteFlowLayout = () => {
   const onClickNext = async () => {
     const currentIndex = pageOrder.indexOf(location.pathname);
 
-    if (currentIndex !== -1 && currentIndex < pageOrder.length - 1) {
+    if (currentIndex < pageOrder.length - 1) {
       if (currentIndex === 0) {
         navigate(pageOrder[currentIndex + 1]);
       } else if (currentIndex === 1) {
@@ -116,11 +117,19 @@ const DiaryWriteFlowLayout = () => {
     return false;
   });
 
+  useEffect(() => {
+    const setKeywordToDiary = async () => {
+      await postKeyword({ diaryId: diaryId, keywords: keywords });
+    };
+
+    if (diaryId !== "0") setKeywordToDiary();
+  }, [diaryId]);
+
   return (
     <MobileLayout>
       <Appbar text="일기 작성" backHandler={handleBack}></Appbar>
       <div className="flex-grow overflow-scroll px-800 py-300">
-        <Outlet context={{ diaryInfo, setDiaryInfo, diaryId }} />
+        <Outlet context={{ diaryInfo, setDiaryInfo, diaryId, setKeywords }} />
       </div>
       <div className="my-4 flex justify-center">
         <Button

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -8,6 +8,7 @@ import DiaryWriteFlowLayout from "../pages/write/Layout/DiaryWriteFlowLayout";
 import { ErrorBoundary } from "react-error-boundary";
 import AlbumFallback from "../components/pages/album/fallback/AlbumFallback";
 import DiaryFallback from "../pages/diary/Fallback/DiaryFallback";
+import StatsFallback from "@/pages/stats/Fallback/StatsFallback";
 
 const HomePage = lazy(() => import("../pages/Home"));
 const ExplorePage = lazy(() => import("../pages/Explore"));
@@ -85,7 +86,7 @@ const routes: RouteObject[] = [
           {
             path: `emotion`,
             element: (
-              <Suspense fallback={<DiaryFallback />}>
+              <Suspense fallback={<StatsFallback />}>
                 <EmotionStatsLayout />
               </Suspense>
             ),
@@ -93,7 +94,7 @@ const routes: RouteObject[] = [
           {
             path: `keyword`,
             element: (
-              <Suspense fallback={<DiaryFallback />}>
+              <Suspense fallback={<StatsFallback />}>
                 <KeywordStatsLayout />
               </Suspense>
             ),

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -149,11 +149,16 @@ export default {
           opacity: "1",
         },
       },
+      customPulse: {
+        "0%, 100%": { opacity: 1 },
+        "50%": { opacity: 0.5 },
+      },
     },
     animation: {
       fadeInSlideUp: "fadeInSlideUp 0.5s ease-out forwards",
       fadeInSlideDown: "fadeInSlideDown 0.5s ease-out forwards",
       fadeIn: "fadeIn 0.5s ease-out forwards",
+      pulse: "customPulse 1.5s cubic-bezier(0.4, 0, 0.6, 1) infinite",
     },
     backdropBlur: {
       default: "25px",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1281,6 +1281,18 @@
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.59.20.tgz#356718976536727b9af0ad1163a21fd6a44ee0a9"
   integrity sha512-e8vw0lf7KwfGe1if4uPFhvZRWULqHjFcz3K8AebtieXvnMOz5FSzlZe3mTLlPuUBcydCnBRqYs2YJ5ys68wwLg==
 
+"@tanstack/query-devtools@5.59.20":
+  version "5.59.20"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-devtools/-/query-devtools-5.59.20.tgz#a827ac682ec1268fc9c99e7b6eb739f35b5606aa"
+  integrity sha512-vxhuQ+8VV4YWQSFxQLsuM+dnEKRY7VeRzpNabFXdhEwsBYLrjXlF1pM38A8WyKNLqZy8JjyRO8oP4Wd/oKHwuQ==
+
+"@tanstack/react-query-devtools@^5.60.5":
+  version "5.60.5"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query-devtools/-/react-query-devtools-5.60.5.tgz#fe398b4896a292fbe835d3fd4799e929de94c25a"
+  integrity sha512-lzANl0ih3CNKBGUoXhhkAAHI1Y4Yqs9Jf3iuTUsGiPpmF0RWXTeYFaQxc+h1PhJz3VwYrIYCwmPoNts0mSjSuA==
+  dependencies:
+    "@tanstack/query-devtools" "5.59.20"
+
 "@tanstack/react-query@^5.59.20":
   version "5.59.20"
   resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.59.20.tgz#bacf1983f44c5690bb99b518f2ef71dc2fa875a4"


### PR DESCRIPTION
## 이슈
- #62 
- #37 
- #48 
- #34 

## 구현 내용
- [x] 쿼리 디버깅 툴 설치
- [x] 탐색, 앨범 5분 캐싱
- [x] 이미지 추가 뒤로가기 개선
- [x] 일기 생성 뒤로가기 개선
- [x] 통계 페이지 router 수정
- [x] 통계 페이지 fallback
- [x] drag, longPress 겹치지 않도록 수정

## 상세 내용
### 통계 페이지 fallback
![image](https://github.com/user-attachments/assets/411c64b0-b4cc-41f0-87bc-d1cf243f3942)

## 고민한 내용
### 뒤로가기 제어
- 웹앱에서의 뒤로가기 특성을 유지하기 위한 고민
- 단순히 버튼으로만 뒤로가기를 제어하면 간단했지만 모바일 환경에서는 필연적으로 뒤로가기를 많이 사용할 것으로 예상함
- 이에 따라 뒤로가기 로직 처리가 필수적이었음

1. 일기 조회 > 수정 > 일기 조회
- 이 플로우에서 수정 후 뒤로가기하면 수정 페이지로 다시 진입하게 되는 문제

2. 일기 조회 > 이미지 추가 > 이미지 생성 > 일기 조회
- 이 플로우에서 이미지 생성 후 뒤로가기하면 일기 조회로 돌아옴
- 일기 조회에서 뒤로가기하면 이미지 생성 페이지로 가서 빠져나올 수 없는 문제

위 두가지 문제를 해결하기 위해 다음과 같은 로직을 둠
- 만약 현재 위치의 상태(location.state)에 from 속성이 있고, 그 값이 RoutePaths.diaryDraw와 같다면, 사용자를 루트 경로로 이동
- 그렇지 않으면 사용자를 2단계 뒤로 이동 `navigate(-2)`
- Appbar의 핸들러는 조건에 따라 루트로 이동, 그렇지 않으면 1단계 뒤로 이동

### 리액트 쿼리 디버그
```tsx
<QueryClientProvider client={queryClient}>
  <App />
  <ReactQueryDevtools initialIsOpen={false} />
</QueryClientProvider>
```
디버그 툴을 추가해 주었음

### 드래그 판단 방식
- 드래그하지 않고 꾹 누르면 이미지 설정이 떠야 함
- 드래그하면 꾹 누르게 되기 때문에 이를 분리해서 입력받을 수 있어야 했음
- 드래그 상태를 받아오도록 변경
```tsx
const isDraggingRef = useRef(false);

const startLongPress = (img: DiaryImage) => {
  if (onLongPress) {
    isDraggingRef.current = false;

    longPressTimerRef.current = setTimeout(() => {
      if (!isDraggingRef.current) {
        onLongPress(img);
      }
    }, 500);
  }
};
```
`isDraggingRef`를 추가해서 드래그 상태를 추적함